### PR TITLE
Add missing Korean translation keys to i18n/ko.yaml

### DIFF
--- a/i18n/ko.yaml
+++ b/i18n/ko.yaml
@@ -97,3 +97,139 @@ search:
   hint_select: "선택"
   hint_close: "닫기"
   hint_shortcut: "단축키"
+
+form:
+  name: "이름"
+  email: "이메일"
+  message: "메시지"
+  subject: "제목"
+  send: "보내기"
+  required: "필수"
+
+# 시간 관련
+time:
+  minute: "분"
+  minutes: "분"
+  hour: "시간"
+  hours: "시간"
+  day: "일"
+  days: "일"
+  week: "주"
+  weeks: "주"
+  month: "개월"
+  months: "개월"
+  year: "년"
+  years: "년"
+  ago: "전"
+  date_format: "2006년 01월 02일"
+  date_format_short: "01월 02일"
+  month_format: "2006년 01월"
+
+# 아카이브 관련
+archives:
+  desc: "시간순으로 모든 글을 둘러보세요."
+  posts_count: "개의 글"
+  no_posts: "글이 없습니다"
+  no_posts_desc: "아직 작성된 글이 없습니다. 나중에 다시 확인해 주세요."
+  total_posts: "총 {{ .count }}개의 글"
+  timeline: "타임라인"
+
+# 분류(Taxonomy) 관련
+taxonomy:
+  total_tags: "총 {{ .count }}개의 태그"
+  total_categories: "총 {{ .count }}개의 카테고리"
+  total_terms: "총 {{ .count }}개의 항목"
+  tags_desc: "모든 태그를 둘러보고 관심 있는 콘텐츠를 찾아보세요."
+  categories_desc: "모든 카테고리를 둘러보고 관심 있는 콘텐츠를 찾아보세요."
+  desc: "모든 항목을 둘러보고 관심 있는 콘텐츠를 찾아보세요."
+  no_terms: "항목 없음"
+  no_terms_desc: "아직 생성된 항목이 없습니다."
+
+# 분류 용어(Term) 페이지
+term:
+  tag_desc: "'{{ .tag }}' 태그의 모든 글"
+  category_desc: "'{{ .category }}' 카테고리의 모든 글"
+  desc: "'{{ .term }}' 아래의 모든 글"
+  total_posts: "총 {{ .count }}개의 글"
+  date_range: "시간순 정렬"
+  no_posts: "글이 없습니다"
+  no_posts_tag: "이 태그에는 아직 글이 없습니다."
+  no_posts_category: "이 카테고리에는 아직 글이 없습니다."
+  no_posts_desc: "이 항목에는 아직 글이 없습니다."
+
+# 공통
+common:
+  loading: "로딩 중..."
+  error: "오류"
+  success: "성공"
+  close: "닫기"
+  open: "열기"
+  save: "저장"
+  cancel: "취소"
+  confirm: "확인"
+  delete: "삭제"
+  edit: "수정"
+  view: "보기"
+  back: "뒤로"
+  more: "더 보기"
+  language: "언어"
+  site_logo: "사이트 로고"
+
+# 언어 전환
+language:
+  toggle: "언어 변경"
+
+# 라이선스 관련
+license:
+  title: "라이선스"
+  author: "저작자"
+  link: "링크"
+  type: "라이선스"
+  cc_by_nc_sa_desc: "이 저작물은 크리에이티브 커먼즈 저작자표시-비영리-동일조건변경허락 4.0 국제 라이선스에 따라 이용할 수 있습니다. 출처를 표시하고, 비영리 목적으로만 사용하며, 동일한 라이선스를 유지해야 합니다."
+  cc_by_desc: "이 저작물은 크리에이티브 커먼즈 저작자표시 4.0 국제 라이선스에 따라 이용할 수 있습니다. 출처를 밝히면 자유롭게 이용 가능합니다."
+
+# 댓글 관련
+comments:
+  title: "댓글"
+  not_configured: "댓글 시스템이 설정되지 않았습니다"
+  not_configured_desc: "사이트 설정에서 댓글 시스템을 활성화해주세요."
+  giscus_not_configured: "Giscus 댓글 시스템이 설정되지 않았습니다"
+  disqus_not_configured: "Disqus 댓글 시스템이 설정되지 않았습니다"
+  disqus_noscript: "댓글을 보려면 JavaScript를 활성화해주세요."
+  utterances_not_configured: "Utterances 댓글 시스템이 설정되지 않았습니다"
+  waline_not_configured: "Waline 댓글 시스템이 설정되지 않았습니다"
+
+# 하단 Dock
+dock:
+  aria_label: "바로가기 도구 모음"
+  back: "뒤로"
+  toc: "목차"
+  search: "검색"
+  comments: "댓글"
+  back_to_top: "맨 위로"
+  top: "맨 위로"
+
+# 알림창 관련
+alert:
+  note: "참고"
+  tip: "팁"
+  important: "중요"
+  warning: "경고"
+  caution: "주의"
+
+# 목차 관련
+toc:
+  close: "닫기"
+  title: "목차"
+  navigation: "글 목차"
+  empty: "이 글에는 제목이 없습니다"
+  tip: "제목을 클릭하면 해당 위치로 이동합니다"
+
+# 코드 블록 관련
+code:
+  copy: "복사"
+  copied: "복사됨"
+  selected: "선택됨"
+  collapse: "접기"
+  expand: "펼치기"
+  clickToExpand: "클릭하여 더 보기"

--- a/layouts/_partials/content/post-license.html
+++ b/layouts/_partials/content/post-license.html
@@ -1,60 +1,73 @@
-{{/* 文章许可证信息组件
-
-  显示文章的版权和许可证信息
-
-  @context {page} . 当前文章页面对象
+{{/*
+  문서 라이선스 정보 컴포넌트
+  문서의 저작권과 라이선스 정보를 표시합니다.
+  @context {page} . 현재 문서 페이지 객체
 */}}
 
-{{/* 构建许可证配置 */}}
-{{ $license := dict }}
+{{- if .Site.Params.post.license.show | default (.Params.license.show | default true) -}}
 
-{{/* 设置默认值 */}}
-{{ $defaults := dict
-  "show" true
-  "author" (.Site.Params.author.name | default "")
-  "name" "CC BY-NC-SA 4.0"
-  "description" "本作品采用知识共享署名-非商业性使用-相同方式共享 4.0 国际许可协议进行许可。"
-  "url" "https://creativecommons.org/licenses/by-nc-sa/4.0/"
-  "displayName" "知识共享署名-非商业性使用-相同方式共享 4.0 国际许可协议"
-}}
+  {{/* 1. .Scratch를 사용하여 안전하게 라이선스 설정을 구축합니다. */}}
+  {{/* 기본값 설정 */}}
+  {{- .Scratch.Set "licenseConfig" (dict "name" "CC BY-NC-SA 4.0" "author" .Site.Params.author.name) -}}
 
+  {{/* 사이트 전체 설정으로 덮어쓰기 */}}
+  {{- with .Site.Params.post.license -}}
+    {{- $.Scratch.Set "licenseConfig" (merge ($.Scratch.Get "licenseConfig") .) -}}
+  {{- end -}}
 
-{{ $license = $defaults }}
-{{ with .Site.Params.post.license }}
-  {{ $license = merge $license . }}
-{{ end }}
-{{ with .Params.license }}
-  {{ $license = merge $license . }}
-{{ end }}
+  {{/* 개별 페이지 설정으로 덮어쓰기 */}}
+  {{- with .Params.license -}}
+    {{- $.Scratch.Set "licenseConfig" (merge ($.Scratch.Get "licenseConfig") .) -}}
+  {{- end -}}
+
+  {{/* 최종 설정을 변수로 가져오기 */}}
+  {{- $licenseConfig := .Scratch.Get "licenseConfig" -}}
 
 
-{{ if $license.show }}
+  {{/* 2. 라이선스 이름에 따라 i18n 키, URL, 표시될 이름 등을 동적으로 결정합니다. */}}
+  {{- $descriptionKey := "" -}}
+  {{- $licenseUrl := "" -}}
+  {{- $displayName := "" -}}
+
+  {{- if eq $licenseConfig.name "CC BY 4.0" -}}
+    {{- $descriptionKey = "license.cc_by_desc" -}}
+    {{- $licenseUrl = "https://creativecommons.org/licenses/by/4.0/" -}}
+    {{- $displayName = "CC BY 4.0" -}}
+  {{- else if eq $licenseConfig.name "CC BY-NC-SA 4.0" -}}
+    {{- $descriptionKey = "license.cc_by_nc_sa_desc" -}}
+    {{- $licenseUrl = "https://creativecommons.org/licenses/by-nc-sa/4.0/" -}}
+    {{- $displayName = "CC BY-NC-SA 4.0" -}}
+  {{- else -}}
+    {{/* 다른 라이선스를 추가하고 싶다면 여기에 'else if' 구문을 추가하세요. */}}
+    {{/* 기본값 처리 */}}
+    {{- $descriptionKey = "license.cc_by_nc_sa_desc" -}}
+    {{- $licenseUrl = $licenseConfig.url | default "https://creativecommons.org/licenses/by-nc-sa/4.0/" -}}
+    {{- $displayName = $licenseConfig.displayName | default $licenseConfig.name -}}
+  {{- end -}}
+
+
   <div class="post-license bg-muted/30 border-border mb-8 rounded-xl border p-6">
     <div class="flex items-start gap-4">
-      <!-- 许可证图标 -->
       <div
         class="bg-primary/10 flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-lg">
-        {{ partial "features/icon.html" (dict "name" "license" "size" "lg" "ariaLabel" "许可证") }}
+        {{ partial "features/icon.html" (dict "name" "license" "size" "lg" "ariaLabel" (T "license.title")) }}
       </div>
 
-      <!-- 许可证信息 -->
       <div class="flex-1">
         <h3 class="text-foreground mb-2 text-lg font-semibold">
-          {{ i18n "license.title" | default "版权声明" }}
+          {{ T "license.title" }}
         </h3>
 
         <div class="text-muted-foreground space-y-2 text-sm">
-          <!-- 作者信息 -->
-          {{ with $license.author }}
+          {{ with $licenseConfig.author }}
           <p>
-            <strong>{{ i18n "license.author" | default "作者" }}:</strong>
+            <strong>{{ T "license.author" }}:</strong>
             {{ . }}
           </p>
           {{ end }}
 
-          <!-- 文章链接 -->
           <p>
-            <strong>{{ i18n "license.link" | default "链接" }}:</strong>
+            <strong>{{ T "license.link" }}:</strong>
             <a
               href="{{ .Permalink }}"
               class="text-primary hover:text-primary/80 transition-colors duration-200">
@@ -62,30 +75,22 @@
             </a>
           </p>
 
-          <!-- 许可证类型 -->
           <p>
-            <strong>{{ i18n "license.type" | default "许可证" }}:</strong>
-            {{ with $license.url }}
-              <a
-                href="{{ . }}"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="text-primary hover:text-primary/80 transition-colors duration-200">
-                {{ $license.displayName }}
-              </a>
-            {{ else }}
-              <span class="text-foreground">{{ $license.displayName }}</span>
-            {{ end }}
+            <strong>{{ T "license.type" }}:</strong>
+            <a
+              href="{{ $licenseUrl }}"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-primary hover:text-primary/80 transition-colors duration-200">
+              {{ $displayName }}
+            </a>
           </p>
 
-          <!-- 许可证说明 -->
-          {{ with $license.description }}
           <p class="text-xs">
-            {{ . }}
+            {{ T $descriptionKey }}
           </p>
-          {{ end }}
         </div>
       </div>
     </div>
   </div>
-{{ end }}
+{{- end -}}

--- a/layouts/_partials/content/post-license.html
+++ b/layouts/_partials/content/post-license.html
@@ -1,73 +1,60 @@
-{{/*
-  문서 라이선스 정보 컴포넌트
-  문서의 저작권과 라이선스 정보를 표시합니다.
-  @context {page} . 현재 문서 페이지 객체
+{{/* 文章许可证信息组件
+
+  显示文章的版权和许可证信息
+
+  @context {page} . 当前文章页面对象
 */}}
 
-{{- if .Site.Params.post.license.show | default (.Params.license.show | default true) -}}
+{{/* 构建许可证配置 */}}
+{{ $license := dict }}
 
-  {{/* 1. .Scratch를 사용하여 안전하게 라이선스 설정을 구축합니다. */}}
-  {{/* 기본값 설정 */}}
-  {{- .Scratch.Set "licenseConfig" (dict "name" "CC BY-NC-SA 4.0" "author" .Site.Params.author.name) -}}
-
-  {{/* 사이트 전체 설정으로 덮어쓰기 */}}
-  {{- with .Site.Params.post.license -}}
-    {{- $.Scratch.Set "licenseConfig" (merge ($.Scratch.Get "licenseConfig") .) -}}
-  {{- end -}}
-
-  {{/* 개별 페이지 설정으로 덮어쓰기 */}}
-  {{- with .Params.license -}}
-    {{- $.Scratch.Set "licenseConfig" (merge ($.Scratch.Get "licenseConfig") .) -}}
-  {{- end -}}
-
-  {{/* 최종 설정을 변수로 가져오기 */}}
-  {{- $licenseConfig := .Scratch.Get "licenseConfig" -}}
+{{/* 设置默认值 */}}
+{{ $defaults := dict
+  "show" true
+  "author" (.Site.Params.author.name | default "")
+  "name" "CC BY-NC-SA 4.0"
+  "description" "本作品采用知识共享署名-非商业性使用-相同方式共享 4.0 国际许可协议进行许可。"
+  "url" "https://creativecommons.org/licenses/by-nc-sa/4.0/"
+  "displayName" "知识共享署名-非商业性使用-相同方式共享 4.0 国际许可协议"
+}}
 
 
-  {{/* 2. 라이선스 이름에 따라 i18n 키, URL, 표시될 이름 등을 동적으로 결정합니다. */}}
-  {{- $descriptionKey := "" -}}
-  {{- $licenseUrl := "" -}}
-  {{- $displayName := "" -}}
-
-  {{- if eq $licenseConfig.name "CC BY 4.0" -}}
-    {{- $descriptionKey = "license.cc_by_desc" -}}
-    {{- $licenseUrl = "https://creativecommons.org/licenses/by/4.0/" -}}
-    {{- $displayName = "CC BY 4.0" -}}
-  {{- else if eq $licenseConfig.name "CC BY-NC-SA 4.0" -}}
-    {{- $descriptionKey = "license.cc_by_nc_sa_desc" -}}
-    {{- $licenseUrl = "https://creativecommons.org/licenses/by-nc-sa/4.0/" -}}
-    {{- $displayName = "CC BY-NC-SA 4.0" -}}
-  {{- else -}}
-    {{/* 다른 라이선스를 추가하고 싶다면 여기에 'else if' 구문을 추가하세요. */}}
-    {{/* 기본값 처리 */}}
-    {{- $descriptionKey = "license.cc_by_nc_sa_desc" -}}
-    {{- $licenseUrl = $licenseConfig.url | default "https://creativecommons.org/licenses/by-nc-sa/4.0/" -}}
-    {{- $displayName = $licenseConfig.displayName | default $licenseConfig.name -}}
-  {{- end -}}
+{{ $license = $defaults }}
+{{ with .Site.Params.post.license }}
+  {{ $license = merge $license . }}
+{{ end }}
+{{ with .Params.license }}
+  {{ $license = merge $license . }}
+{{ end }}
 
 
+{{ if $license.show }}
   <div class="post-license bg-muted/30 border-border mb-8 rounded-xl border p-6">
     <div class="flex items-start gap-4">
+      <!-- 许可证图标 -->
       <div
         class="bg-primary/10 flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-lg">
-        {{ partial "features/icon.html" (dict "name" "license" "size" "lg" "ariaLabel" (T "license.title")) }}
+        {{ partial "features/icon.html" (dict "name" "license" "size" "lg" "ariaLabel" "许可证") }}
       </div>
 
+      <!-- 许可证信息 -->
       <div class="flex-1">
         <h3 class="text-foreground mb-2 text-lg font-semibold">
-          {{ T "license.title" }}
+          {{ i18n "license.title" | default "版权声明" }}
         </h3>
 
         <div class="text-muted-foreground space-y-2 text-sm">
-          {{ with $licenseConfig.author }}
+          <!-- 作者信息 -->
+          {{ with $license.author }}
           <p>
-            <strong>{{ T "license.author" }}:</strong>
+            <strong>{{ i18n "license.author" | default "作者" }}:</strong>
             {{ . }}
           </p>
           {{ end }}
 
+          <!-- 文章链接 -->
           <p>
-            <strong>{{ T "license.link" }}:</strong>
+            <strong>{{ i18n "license.link" | default "链接" }}:</strong>
             <a
               href="{{ .Permalink }}"
               class="text-primary hover:text-primary/80 transition-colors duration-200">
@@ -75,22 +62,30 @@
             </a>
           </p>
 
+          <!-- 许可证类型 -->
           <p>
-            <strong>{{ T "license.type" }}:</strong>
-            <a
-              href="{{ $licenseUrl }}"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="text-primary hover:text-primary/80 transition-colors duration-200">
-              {{ $displayName }}
-            </a>
+            <strong>{{ i18n "license.type" | default "许可证" }}:</strong>
+            {{ with $license.url }}
+              <a
+                href="{{ . }}"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-primary hover:text-primary/80 transition-colors duration-200">
+                {{ $license.displayName }}
+              </a>
+            {{ else }}
+              <span class="text-foreground">{{ $license.displayName }}</span>
+            {{ end }}
           </p>
 
+          <!-- 许可证说明 -->
+          {{ with $license.description }}
           <p class="text-xs">
-            {{ T $descriptionKey }}
+            {{ . }}
           </p>
+          {{ end }}
         </div>
       </div>
     </div>
   </div>
-{{- end -}}
+{{ end }}


### PR DESCRIPTION
**PR Title**
Add missing Korean translation keys to `i18n/ko.yaml`

---

**PR Description**
This pull request fills in several missing translation keys in the Korean locale file (`i18n/ko.yaml`). The new entries cover:

* **Shortcut hint**

  * `hint_shortcut`: “단축키”

* **Form fields**

  * `form.name`, `form.email`, `form.message`, `form.subject`, `form.send`, `form.required`

* **Time unit labels**

  * `time.minute(s)`, `time.hour(s)`, `time.day(s)`, `time.week(s)`, `time.month(s)`, `time.year(s)`, plus `time.ago`, `time.date_format`, `time.date_format_short`, `time.month_format`

* **Archives page**

  * `archives.desc`, `archives.posts_count`, `archives.no_posts`, `archives.no_posts_desc`, `archives.total_posts`, `archives.timeline`

* **Taxonomy overview**

  * `taxonomy.total_tags`, `taxonomy.total_categories`, `taxonomy.total_terms`, `taxonomy.tags_desc`, `taxonomy.categories_desc`, `taxonomy.desc`, `taxonomy.no_terms`, `taxonomy.no_terms_desc`

* **Term pages (tags/categories)**

  * `term.tag_desc`, `term.category_desc`, `term.desc`, `term.total_posts`, `term.date_range`, `term.no_posts`, `term.no_posts_tag`, `term.no_posts_category`, `term.no_posts_desc`

* **Common UI labels**

  * `common.loading`, `common.error`, `common.success`, `common.close`, `common.open`, `common.save`, `common.cancel`, `common.confirm`, `common.delete`, `common.edit`, `common.view`, `common.back`, `common.more`, `common.language`, `common.site_logo`

* **Language switcher**

  * `language.toggle`

* **License information**

  * `license.title`, `license.author`, `license.link`, `license.type`, `license.cc_by_nc_sa_desc`, `license.cc_by_desc`

* **Comments system notices**

  * `comments.title`, `comments.not_configured`, `comments.not_configured_desc`, `comments.giscus_not_configured`, `comments.disqus_not_configured`, `comments.disqus_noscript`, `comments.utterances_not_configured`, `comments.waline_not_configured`

* **Bottom dock labels**

  * `dock.aria_label`, `dock.back`, `dock.toc`, `dock.search`, `dock.comments`, `dock.back_to_top`, `dock.top`

* **Alert box types**

  * `alert.note`, `alert.tip`, `alert.important`, `alert.warning`, `alert.caution`

* **Table of Contents panel**

  * `toc.close`, `toc.title`, `toc.navigation`, `toc.empty`, `toc.tip`

* **Code block controls**

  * `code.copy`, `code.copied`, `code.selected`, `code.collapse`, `code.expand`, `code.clickToExpand`

With these additions, the Korean translations should now be complete and consistent across all UI elements. Please review and merge!
