### PR TITLE
Fix codeblock and readingProgress in configuration

### DIFF
--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -323,7 +323,21 @@ params:
     rowHeightTolerance: 0.25
     maxRowsCount: 999999
     calculateItemsHeight: false
-
+  
+  codeblock:
+    collapse:
+      enabled: true
+      defaultState: expanded  # expanded, collapsed
+      autoCollapseLines: 30
+      autoCollapseHeight: 400
+      collapsedHeight: 120
+  
+  readingProgress:
+    enabled: true
+    height: 3
+    showOnHomepage: false
+    smoothScroll: true
+    hideOnComplete: false
 
 markup:
   tableOfContents:
@@ -341,25 +355,6 @@ markup:
     noClasses: false
     style: github # No need to change
     tabWidth: 2
-
-
-codeblock:
-  collapse:
-    enabled: true
-    defaultState: expanded  # expanded, collapsed
-    autoCollapseLines: 30
-    autoCollapseHeight: 400
-    collapsedHeight: 120
-
-readingProgress:
-  enabled: true
-  height: 3
-  showOnHomepage: false
-  smoothScroll: true
-  hideOnComplete: false
-
-
-
 
 outputs:
   home: ["HTML", "RSS", "JSON", "WebAppManifest"]


### PR DESCRIPTION
`codeblock` and `readingProgress` should be under params section in `hugo.yaml` instead of top level