### PR TITLE
Refactor date formatting to use Hugo functions

### DIFF
--- a/layouts/_partials/content/card-base.html
+++ b/layouts/_partials/content/card-base.html
@@ -77,7 +77,7 @@
             <div class="flex items-center gap-1.5">
               {{ partial "features/icon.html" (dict "name" "calendar" "size" "sm" "ariaLabel" (i18n "post.published_on")) }}
               <time datetime="{{ $page.Date.Format "2006-01-02" }}" class="font-medium">
-                {{ $page.Date.Format (i18n "time.date_format" | default "2006年01月02日") }}
+                {{ dateFormat (i18n "time.date_format" | default "2006年01月02日") $page.Date }}
               </time>
             </div>
             {{ if $page.ReadingTime }}

--- a/layouts/_partials/content/post-meta.html
+++ b/layouts/_partials/content/post-meta.html
@@ -44,7 +44,7 @@
               {{ partial "features/icon.html" (dict "name" "calendar" "size" "sm" "ariaLabel" (i18n
               "post.published_on")) }}
               <time datetime="{{ .Date.Format `2006-01-02` }}">
-                {{ .Date.Format (i18n "time.date_format" | default "2006年01月02日") }}
+                {{ dateFormat (i18n "time.date_format" | default "2006年01月02日") .Date }}
               </time>
             </div>
 
@@ -54,7 +54,7 @@
               {{ partial "features/icon.html" (dict "name" "edit" "size" "sm" "ariaLabel" (i18n "post.updated_on")) }}
               <span>
                 {{ i18n "post.updated_on" | default "更新于" }}
-                {{ .Lastmod.Format (i18n "time.date_format" | default "2006年01月02日") }}
+                {{ dateFormat (i18n "time.date_format" | default "2006年01月02日") .Lastmod }}
               </span>
             </div>
             {{ end }}

--- a/layouts/_partials/content/post-navigation.html
+++ b/layouts/_partials/content/post-navigation.html
@@ -37,7 +37,7 @@
               class="text-muted-foreground mt-auto flex items-center gap-2 text-xs">
               {{ partial "features/icon.html" (dict "name" "calendar" "size" "xs" "ariaLabel" "") }}
               <time datetime="{{ $prev.Date.Format "2006-01-02" }}">
-                {{ $prev.Date.Format (i18n "time.date_format_short" | default "01月02日") }}
+                {{ dateFormat (i18n "time.date_format_short" | default "01月02日") $prev.Date }}
               </time>
             </div>
           </a>
@@ -80,7 +80,7 @@
             <div
               class="text-muted-foreground mt-auto flex items-center justify-end gap-2 text-xs">
               <time datetime="{{ $next.Date.Format "2006-01-02" }}">
-                {{ $next.Date.Format (i18n "time.date_format_short" | default "01月02日") }}
+                {{ dateFormat (i18n "time.date_format_short" | default "01月02日") $next.Date }}
               </time>
               {{ partial "features/icon.html" (dict "name" "calendar" "size" "xs" "ariaLabel" "") }}
             </div>

--- a/layouts/archives.html
+++ b/layouts/archives.html
@@ -71,7 +71,7 @@
                 <div class="ml-12">
                   {{ $date := time (printf "%s-01" .Key) }}
                   <h3 class="text-foreground text-lg font-semibold">
-                    {{ $date.Format (i18n "time.month_format" | default "2006年01月") }}
+                    {{ time.Format (i18n "time.month_format" | default "2006年01月") $date }}
                   </h3>
                   <p class="text-muted-foreground text-xs">
                     {{ len .Pages }}
@@ -100,7 +100,7 @@
                           <div class="flex items-center gap-1">
                             {{ partial "features/icon.html" (dict "name" "calendar" "size" "xs" "ariaLabel" "") }}
                             <time datetime="{{ .Date.Format "2006-01-02" }}">
-                              {{ .Date.Format "01-02" }}
+                              {{ dateFormat (i18n "time.date_format_short" | default "01-02") .Date }}
                             </time>
                           </div>
 

--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -61,7 +61,7 @@
         {{ partial "features/icon.html" (dict "name" "calendar" "size" "sm" "ariaLabel" "") }}
         <span class="text-muted-foreground">{{ i18n "post.published_on" | default "Published on" }}:</span>
         <time datetime="{{ .Date.Format "2006-01-02" }}" class="text-foreground font-medium">
-          {{ .Date.Format (i18n "time.date_format" | default "January 02, 2006") }}
+          {{ dateFormat (i18n "time.date_format" | default "January 02, 2006") .Date }}
         </time>
       </div>
 
@@ -89,9 +89,9 @@
     {{ if or .Params.github .Params.demo .Params.website }}
       <div class="mt-4 flex flex-wrap gap-3">
         {{ if .Params.github }}
-          <a 
-            href="{{ .Params.github }}" 
-            target="_blank" 
+          <a
+            href="{{ .Params.github }}"
+            target="_blank"
             rel="noopener noreferrer"
             class="bg-card border-border hover:bg-primary/5 hover:border-primary/20 inline-flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium transition-colors">
             {{ partial "features/icon.html" (dict "name" "github" "size" "sm" "ariaLabel" "") }}
@@ -99,9 +99,9 @@
           </a>
         {{ end }}
         {{ if .Params.demo }}
-          <a 
-            href="{{ .Params.demo }}" 
-            target="_blank" 
+          <a
+            href="{{ .Params.demo }}"
+            target="_blank"
             rel="noopener noreferrer"
             class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors">
             {{ partial "features/icon.html" (dict "name" "link" "size" "sm" "ariaLabel" "") }}
@@ -109,9 +109,9 @@
           </a>
         {{ end }}
         {{ if .Params.website }}
-          <a 
-            href="{{ .Params.website }}" 
-            target="_blank" 
+          <a
+            href="{{ .Params.website }}"
+            target="_blank"
             rel="noopener noreferrer"
             class="bg-card border-border hover:bg-primary/5 hover:border-primary/20 inline-flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium transition-colors">
             {{ partial "features/icon.html" (dict "name" "link" "size" "sm" "ariaLabel" "") }}
@@ -147,4 +147,3 @@
   {{ partial "features/comments.html" . }}
 
 {{ end }}
-


### PR DESCRIPTION
Ensure the formats in i18n/lang.yml are always defined in English.
```yaml
time:
  date_format: "02 January 2006"
  date_format_short: "02 Jan"
  month_format: "January 2006"
```