### PR TITLE
feat: Add dropdown submenu support in header navigation

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -16,6 +16,11 @@
   overflow-y: auto;
 }
 
+/* 导航子菜单 */
+.nav-submenu {
+  min-width: 10rem;
+}
+
 .search-result-selected {
   background-color: color-mix(in srgb, var(--color-primary) 10%, transparent) !important;
   color: var(--color-primary) !important;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -91,6 +91,28 @@ class UIManager {
           }
         }
       });
+
+    // 关闭所有导航子菜单
+    document.querySelectorAll(".nav-submenu").forEach(submenu => {
+      submenu.classList.add("hidden");
+      const id = submenu.getAttribute("data-submenu-id");
+      const toggle = document.querySelector(`.nav-submenu-toggle[data-submenu-id="${id}"]`);
+      if (toggle) {
+        toggle.setAttribute("aria-expanded", "false");
+        toggle.querySelector(".submenu-chevron")?.classList.remove("rotate-180");
+      }
+    });
+
+    // 关闭所有移动端子菜单
+    document.querySelectorAll(".mobile-submenu").forEach(submenu => {
+      submenu.classList.add("hidden");
+      const id = submenu.getAttribute("data-submenu-id");
+      const toggle = document.querySelector(`.mobile-submenu-toggle[data-submenu-id="${id}"]`);
+      if (toggle) {
+        toggle.setAttribute("aria-expanded", "false");
+        toggle.querySelector(".submenu-chevron")?.classList.remove("rotate-180");
+      }
+    });
   }
 
   // 关闭移动端菜单 - 保持向后兼容
@@ -133,12 +155,53 @@ class UIManager {
     // 实际的事件处理由 setupDropdown("mobile-menu") 完成
   }
 
+  // 设置导航子菜单（桌面端下拉，移动端手风琴）
+  setupNavSubmenus() {
+    // 桌面端：点击父项切换下拉子菜单
+    document.querySelectorAll(".nav-submenu-toggle").forEach(toggle => {
+      toggle.addEventListener("click", (e) => {
+        e.stopPropagation();
+        const id = toggle.getAttribute("data-submenu-id");
+        const submenu = document.querySelector(`.nav-submenu[data-submenu-id="${id}"]`);
+        if (!submenu) return;
+
+        const isOpen = !submenu.classList.contains("hidden");
+
+        // 关闭所有菜单（包括此子菜单）
+        this.closeAllMenus();
+
+        // 若之前是关闭状态，则打开
+        if (!isOpen) {
+          submenu.classList.remove("hidden");
+          toggle.setAttribute("aria-expanded", "true");
+          toggle.querySelector(".submenu-chevron")?.classList.add("rotate-180");
+        }
+      });
+    });
+
+    // 移动端：点击父项折叠/展开子菜单
+    document.querySelectorAll(".mobile-submenu-toggle").forEach(toggle => {
+      toggle.addEventListener("click", (e) => {
+        e.stopPropagation();
+        const id = toggle.getAttribute("data-submenu-id");
+        const submenu = document.querySelector(`.mobile-submenu[data-submenu-id="${id}"]`);
+        if (!submenu) return;
+
+        const isHidden = submenu.classList.contains("hidden");
+        submenu.classList.toggle("hidden");
+        toggle.setAttribute("aria-expanded", isHidden ? "true" : "false");
+        toggle.querySelector(".submenu-chevron")?.classList.toggle("rotate-180", isHidden);
+      });
+    });
+  }
+
   setupEventListeners() {
     // 设置所有下拉菜单，包括移动端菜单
     this.setupDropdown("mobile-menu");
     this.setupDropdown("color-scheme");
     this.setupDropdown("theme");
     this.setupDropdown("language");
+    this.setupNavSubmenus();
 
     // 主题风格选择事件
     const colorSchemeDropdowns = document.querySelectorAll(
@@ -177,7 +240,7 @@ class UIManager {
     // 点击外部关闭所有菜单 - 统一处理
     document.addEventListener("click", (e) => {
       // 检查是否点击在任何菜单相关元素内
-      const isClickInsideMenu = e.target.closest('.dropdown-toggle, .dropdown-menu');
+      const isClickInsideMenu = e.target.closest('.dropdown-toggle, .dropdown-menu, .nav-submenu-toggle, .nav-submenu');
 
       // 如果点击在外部，关闭所有菜单
       if (!isClickInsideMenu) {

--- a/exampleSite/config/_default/menus.yaml
+++ b/exampleSite/config/_default/menus.yaml
@@ -25,6 +25,29 @@ main:
     params:
       icon: archive
 
+  # Example: parent item with dropdown submenu children
+  - identifier: nav.more
+    name: More
+    weight: 50
+    params:
+      icon: layers
+
+  - identifier: nav.more.about
+    name: About
+    pageRef: /about
+    parent: nav.more
+    weight: 1
+    params:
+      icon: about
+
+  - identifier: nav.more.projects
+    name: Projects
+    pageRef: /projects
+    parent: nav.more
+    weight: 2
+    params:
+      icon: projects
+
 # footer menu
 footer:
   - identifier: nav.projects

--- a/layouts/_partials/navigation/header.html
+++ b/layouts/_partials/navigation/header.html
@@ -48,20 +48,67 @@
                 {{ $menuURL = .URL | relLangURL }}
               {{ end }}
             {{ end }}
-            {{ $isActive := eq $currentPage.RelPermalink $menuURL }}
-            <a
-              href="{{ $menuURL }}"
-              class="nav-link {{ if $isActive }}
-                nav-active-indicator bg-accent text-accent-foreground
-              {{ else }}
-                text-muted-foreground hover:text-primary hover:bg-primary/10
-              {{ end }} focus:ring-primary/20 relative flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-all duration-300 ease-out hover:-translate-y-0.5 hover:scale-105 focus:ring-2 focus:outline-none"
-            >
-              {{ if .Params.icon }}
-                {{ partial "features/icon.html" (dict "name" .Params.icon "size" "md" "ariaLabel" .Name) }}
-              {{ end }}
-              <span>{{ or (T .Identifier) .Name | safeHTML }}</span>
-            </a>
+            {{ if .HasChildren }}
+              {{/* 有子菜单的父项：渲染为下拉菜单 */}}
+              {{ $identifier := .Identifier }}
+              <div class="relative">
+                <button
+                  class="nav-link nav-submenu-toggle text-muted-foreground hover:text-primary hover:bg-primary/10 focus:ring-primary/20 relative flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-all duration-300 ease-out hover:-translate-y-0.5 hover:scale-105 focus:ring-2 focus:outline-none"
+                  data-submenu-id="{{ $identifier }}"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                >
+                  {{ if .Params.icon }}
+                    {{ partial "features/icon.html" (dict "name" .Params.icon "size" "md" "ariaLabel" .Name) }}
+                  {{ end }}
+                  <span>{{ or (T .Identifier) .Name | safeHTML }}</span>
+                  {{ partial "features/icon.html" (dict "name" "chevron-down" "size" "sm" "class" "submenu-chevron transition-transform duration-200") }}
+                </button>
+                <div
+                  class="nav-submenu border-border bg-popover/95 absolute top-full left-0 z-50 mt-1 hidden min-w-40 rounded-lg border p-1 shadow-lg backdrop-blur-sm"
+                  data-submenu-id="{{ $identifier }}"
+                  role="menu"
+                >
+                  {{ range .Children }}
+                    {{ $childURL := .URL }}
+                    {{ if .PageRef }}
+                      {{ with site.GetPage .PageRef }}
+                        {{ $childURL = .RelPermalink }}
+                      {{ else }}
+                        {{ $childURL = .URL | relLangURL }}
+                      {{ end }}
+                    {{ end }}
+                    {{ $isChildActive := eq $currentPage.RelPermalink $childURL }}
+                    <a
+                      href="{{ $childURL }}"
+                      class="nav-link {{ if $isChildActive }}bg-accent text-accent-foreground{{ else }}text-muted-foreground hover:text-primary hover:bg-primary/10{{ end }} focus:ring-primary/20 flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors duration-200 focus:ring-2 focus:outline-none"
+                      role="menuitem"
+                      {{ if $isChildActive }}aria-current="page"{{ end }}
+                    >
+                      {{ if .Params.icon }}
+                        {{ partial "features/icon.html" (dict "name" .Params.icon "size" "sm" "ariaLabel" .Name) }}
+                      {{ end }}
+                      <span>{{ or (T .Identifier) .Name | safeHTML }}</span>
+                    </a>
+                  {{ end }}
+                </div>
+              </div>
+            {{ else }}
+              {{ $isActive := eq $currentPage.RelPermalink $menuURL }}
+              <a
+                href="{{ $menuURL }}"
+                class="nav-link {{ if $isActive }}
+                  nav-active-indicator bg-accent text-accent-foreground
+                {{ else }}
+                  text-muted-foreground hover:text-primary hover:bg-primary/10
+                {{ end }} focus:ring-primary/20 relative flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-all duration-300 ease-out hover:-translate-y-0.5 hover:scale-105 focus:ring-2 focus:outline-none"
+              >
+                {{ if .Params.icon }}
+                  {{ partial "features/icon.html" (dict "name" .Params.icon "size" "md" "ariaLabel" .Name) }}
+                {{ end }}
+                <span>{{ or (T .Identifier) .Name | safeHTML }}</span>
+              </a>
+            {{ end }}
           {{ end }}
         </div>
       </nav>

--- a/layouts/_partials/navigation/mobile-menu-toggle.html
+++ b/layouts/_partials/navigation/mobile-menu-toggle.html
@@ -31,22 +31,68 @@
             {{ $menuURL = .URL | relLangURL }}
           {{ end }}
         {{ end }}
-        {{ $isActive := eq $currentPage.RelPermalink $menuURL }}
-        <a
-          href="{{ $menuURL }}"
-          class="nav-link {{ if $isActive }}
-            nav-active-indicator bg-accent text-accent-foreground
-          {{ else }}
-            text-muted-foreground hover:text-primary hover:bg-primary/10
-          {{ end }} focus:ring-primary/20 relative flex items-center gap-3 rounded-md px-4 py-3 text-sm font-medium transition-all duration-200 ease-out hover:translate-x-1 focus:ring-2 focus:outline-none"
-          role="menuitem"
-          {{ if $isActive }}aria-current="page"{{ end }}
-        >
-          {{ if .Params.icon }}
-            {{ partial "features/icon.html" (dict "name" .Params.icon "size" "md" "ariaLabel" .Name) }}
-          {{ end }}
-          <span>{{ or (T .Identifier) .Name | safeHTML }}</span>
-        </a>
+        {{ if .HasChildren }}
+          {{/* 有子菜单的父项：渲染为折叠手风琴 */}}
+          {{ $identifier := .Identifier }}
+          <div>
+            <button
+              class="nav-link mobile-submenu-toggle text-muted-foreground hover:text-primary hover:bg-primary/10 focus:ring-primary/20 relative flex w-full items-center gap-3 rounded-md px-4 py-3 text-sm font-medium transition-all duration-200 ease-out focus:ring-2 focus:outline-none"
+              data-submenu-id="{{ $identifier }}"
+              aria-expanded="false"
+              aria-haspopup="true"
+            >
+              {{ if .Params.icon }}
+                {{ partial "features/icon.html" (dict "name" .Params.icon "size" "md" "ariaLabel" .Name) }}
+              {{ end }}
+              <span class="flex-1 text-left">{{ or (T .Identifier) .Name | safeHTML }}</span>
+              {{ partial "features/icon.html" (dict "name" "chevron-down" "size" "sm" "class" "submenu-chevron transition-transform duration-200") }}
+            </button>
+            <div
+              class="mobile-submenu hidden pl-4"
+              data-submenu-id="{{ $identifier }}"
+            >
+              {{ range .Children }}
+                {{ $childURL := .URL }}
+                {{ if .PageRef }}
+                  {{ with site.GetPage .PageRef }}
+                    {{ $childURL = .RelPermalink }}
+                  {{ else }}
+                    {{ $childURL = .URL | relLangURL }}
+                  {{ end }}
+                {{ end }}
+                {{ $isChildActive := eq $currentPage.RelPermalink $childURL }}
+                <a
+                  href="{{ $childURL }}"
+                  class="nav-link {{ if $isChildActive }}nav-active-indicator bg-accent text-accent-foreground{{ else }}text-muted-foreground hover:text-primary hover:bg-primary/10{{ end }} focus:ring-primary/20 relative flex items-center gap-3 rounded-md px-4 py-2.5 text-sm transition-all duration-200 ease-out hover:translate-x-1 focus:ring-2 focus:outline-none"
+                  role="menuitem"
+                  {{ if $isChildActive }}aria-current="page"{{ end }}
+                >
+                  {{ if .Params.icon }}
+                    {{ partial "features/icon.html" (dict "name" .Params.icon "size" "sm" "ariaLabel" .Name) }}
+                  {{ end }}
+                  <span>{{ or (T .Identifier) .Name | safeHTML }}</span>
+                </a>
+              {{ end }}
+            </div>
+          </div>
+        {{ else }}
+          {{ $isActive := eq $currentPage.RelPermalink $menuURL }}
+          <a
+            href="{{ $menuURL }}"
+            class="nav-link {{ if $isActive }}
+              nav-active-indicator bg-accent text-accent-foreground
+            {{ else }}
+              text-muted-foreground hover:text-primary hover:bg-primary/10
+            {{ end }} focus:ring-primary/20 relative flex items-center gap-3 rounded-md px-4 py-3 text-sm font-medium transition-all duration-200 ease-out hover:translate-x-1 focus:ring-2 focus:outline-none"
+            role="menuitem"
+            {{ if $isActive }}aria-current="page"{{ end }}
+          >
+            {{ if .Params.icon }}
+              {{ partial "features/icon.html" (dict "name" .Params.icon "size" "md" "ariaLabel" .Name) }}
+            {{ end }}
+            <span>{{ or (T .Identifier) .Name | safeHTML }}</span>
+          </a>
+        {{ end }}
       {{ end }}
     </nav>
   </div>


### PR DESCRIPTION
As I wanted to add a submenu to the header for my deployment I took the liberty to code it and add it to the main project.

Menu items with children render as a button + absolute dropdown panel with a rotating chevron-down indicator; clicking the parent toggles the panel open/closed. On mobile, parent items become accordion toggles that expand/collapse children inline within the mobile menu panel.

Configuration is purely through Hugo's built-in menu system — any top-level menu item with children (via the parent field) automatically becomes a dropdown, no extra params needed:

Example config:` exampleSite/config/_default/menus.yaml` includes a More parent item with About and Projects children demonstrating the parent field syntax

 ```
# Example: parent item with dropdown submenu children
  - identifier: nav.more
    name: More
    weight: 50
    params:
      icon: layers

  - identifier: nav.more.about
    name: About
    pageRef: /about
    parent: nav.more
    weight: 1
    params:
      icon: about
```
<img width="995" height="368" alt="Scherm­afbeelding 2026-03-09 om 21 03 02" src="https://github.com/user-attachments/assets/6bcd3436-2e7d-4b3e-8132-fed70704556d" />
