### PR TITLE
Feat: Add resume page layout

### DIFF
--- a/archetypes/resume.md
+++ b/archetypes/resume.md
@@ -1,0 +1,70 @@
+---
+title: "Resume"
+layout: "resume"
+description: "Professional resume"
+
+# Personal info
+name: "Your Name"
+jobtitle: "Your Job Title"
+location: "City, Country"
+email: "you@example.com"
+phone: "+1 234 567 8900"
+website: "https://yoursite.com"
+linkedin: "https://linkedin.com/in/yourhandle"
+github: "https://github.com/yourhandle"
+
+# One-paragraph professional summary
+summary: "Experienced professional with X years in..."
+
+# Work experience (most recent first)
+experience:
+  - company: "Company Name"
+    title: "Job Title"
+    location: "City, Country"
+    start: "2022-01"
+    end: ""           # leave empty for "Present"
+    description: ""   # optional paragraph below the title
+    highlights:
+      - "Achievement or responsibility 1"
+      - "Achievement or responsibility 2"
+    stack: ["Tool 1", "Tool 2"]
+
+  - company: "Previous Company"
+    title: "Previous Title"
+    location: "City, Country"
+    start: "2019-06"
+    end: "2021-12"
+    highlights:
+      - "Achievement or responsibility 1"
+    stack: []
+
+# Education (most recent first)
+education:
+  - institution: "University Name"
+    degree: "Degree Name"
+    location: "City, Country"
+    start: "2015"
+    end: "2019"
+    description: ""   # optional: thesis, specialisation, etc.
+
+# Skills grouped by category
+skills:
+  - category: "Languages"
+    items: ["Language 1", "Language 2"]
+  - category: "Tools"
+    items: ["Tool 1", "Tool 2"]
+
+# Optional: certifications
+certifications:
+  - name: "Certification Name"
+    issuer: "Issuing Organisation"
+    date: "2023-04"
+    url: ""           # link to credential, leave empty if none
+
+# Optional: spoken languages
+languages:
+  - language: "English"
+    level: "Native"
+  - language: "Other"
+    level: "Professional"
+---

--- a/assets/css/prose.misc.css
+++ b/assets/css/prose.misc.css
@@ -157,3 +157,54 @@
   max-width: 100%;
   padding: 1em 0;
 }
+
+@media print {
+  @page {
+    margin: 1.5cm;
+  }
+
+  /* hide all chrome */
+  header,
+  footer,
+  [data-dock],
+  .dock,
+  .toc-sidebar,
+  .reading-progress-bar,
+  .resume-print-btn,
+  nav {
+    display: none !important;
+  }
+
+  /* force white/black */
+  body {
+    background: white !important;
+    color: black !important;
+  }
+
+  /* keep cards readable */
+  .bg-card {
+    background: white !important;
+    border-color: #e5e7eb !important;
+    box-shadow: none !important;
+  }
+
+  .text-muted-foreground {
+    color: #6b7280 !important;
+  }
+
+  .text-primary {
+    color: black !important;
+    font-weight: 600;
+  }
+
+  /* avoid splitting entries across pages */
+  .resume-entry {
+    break-inside: avoid;
+  }
+
+  /* remove hover/animation artifacts */
+  * {
+    transition: none !important;
+    animation: none !important;
+  }
+}

--- a/assets/icons/briefcase.svg
+++ b/assets/icons/briefcase.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect width="20" height="14" x="2" y="7" rx="2" ry="2"/>
+  <path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"/>
+</svg>

--- a/assets/icons/printer.svg
+++ b/assets/icons/printer.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="6 9 6 2 18 2 18 9"/>
+  <path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/>
+  <rect width="12" height="8" x="6" y="14"/>
+</svg>

--- a/exampleSite/config/_default/menus.yaml
+++ b/exampleSite/config/_default/menus.yaml
@@ -61,6 +61,12 @@ footer:
     params:
       icon: about
 
+  - name: Resume
+    pageRef: /resume
+    weight: 25
+    params:
+      icon: file-text
+
   - name: RSS Feed
     url: /index.xml
     weight: 30

--- a/exampleSite/content/resume.md
+++ b/exampleSite/content/resume.md
@@ -1,0 +1,92 @@
+---
+title: "Resume"
+layout: "resume"
+description: "Professional resume of Jane Doe"
+
+name: "Jane Doe"
+jobtitle: "Senior Software Engineer"
+location: "Berlin, Germany"
+email: "alex@example.com"
+phone: "+49 30 1234 5678"
+website: "https://alexrivera.dev"
+linkedin: "https://linkedin.com/in/alexrivera"
+github: "https://github.com/alexrivera"
+
+summary: "Software engineer with 9 years of experience building scalable backend systems and developer tools. Passionate about open source, clean APIs, and developer experience. Previously at two Berlin-based startups and one large tech company."
+
+experience:
+  - company: "Meridian Technologies"
+    title: "Senior Software Engineer"
+    location: "Berlin, Germany (Remote)"
+    start: "2021-03"
+    end: ""
+    highlights:
+      - "Redesigned core data pipeline processing 50M events/day, reducing p99 latency from 4s to 280ms"
+      - "Led migration from monolith to event-driven microservices across 6 teams"
+      - "Introduced internal developer platform that cut service onboarding from 3 days to 2 hours"
+      - "Mentored 3 junior engineers through structured 1:1s and design review sessions"
+    stack: ["Go", "Kafka", "Kubernetes", "PostgreSQL", "Terraform", "AWS"]
+
+  - company: "Stackfield GmbH"
+    title: "Backend Engineer"
+    location: "Munich, Germany"
+    start: "2018-07"
+    end: "2021-02"
+    highlights:
+      - "Built real-time collaboration engine powering 200k daily active users"
+      - "Reduced infrastructure costs by 35% through query optimisation and caching strategy"
+      - "Maintained 99.98% uptime across 3 years of on-call rotations"
+    stack: ["Go", "Redis", "WebSockets", "PostgreSQL", "Docker"]
+
+  - company: "Finleap GmbH"
+    title: "Software Engineer"
+    location: "Berlin, Germany"
+    start: "2015-09"
+    end: "2018-06"
+    highlights:
+      - "Developed payment processing integrations for 12 European markets"
+      - "Led adoption of internal API standards adopted across 8 product teams"
+    stack: ["Python", "Django", "PostgreSQL", "React", "REST APIs"]
+
+education:
+  - institution: "Technische Universität Berlin"
+    degree: "M.Sc. Computer Science"
+    location: "Berlin, Germany"
+    start: "2013"
+    end: "2015"
+    description: "Thesis: Adaptive load balancing in distributed key-value stores"
+
+  - institution: "Universität Stuttgart"
+    degree: "B.Sc. Computer Science"
+    location: "Stuttgart, Germany"
+    start: "2010"
+    end: "2013"
+
+skills:
+  - category: "Languages"
+    items: ["Go", "TypeScript", "Python", "Rust", "SQL"]
+  - category: "Infrastructure"
+    items: ["Kubernetes", "Docker", "AWS", "Terraform", "PostgreSQL", "Redis", "Kafka"]
+  - category: "Frontend"
+    items: ["React", "Next.js", "TailwindCSS"]
+  - category: "Practices"
+    items: ["System Design", "API Design", "TDD", "Code Review", "Technical Writing"]
+
+certifications:
+  - name: "AWS Solutions Architect – Professional"
+    issuer: "Amazon Web Services"
+    date: "2022-11"
+    url: ""
+  - name: "Certified Kubernetes Administrator (CKA)"
+    issuer: "Cloud Native Computing Foundation"
+    date: "2021-04"
+    url: ""
+
+languages:
+  - language: "English"
+    level: "Native"
+  - language: "German"
+    level: "Professional (C1)"
+  - language: "Spanish"
+    level: "Basic (A2)"
+---

--- a/i18n/ar.toml
+++ b/i18n/ar.toml
@@ -95,3 +95,14 @@
     featuredProjects = "مشاريع مميزة"
     viewAll          = "عرض الكل"
     recentPosts      = "أحدث المقالات"
+
+[resume]
+  experience     = "الخبرة"
+  education      = "التعليم"
+  skills         = "المهارات"
+  certifications = "الشهادات"
+  languages      = "اللغات"
+  present        = "حتى الآن"
+  print          = "طباعة / حفظ PDF"
+  contact        = "التواصل"
+  summary        = "ملخص"

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -83,3 +83,14 @@
     featuredProjects = "Ausgewählte Projekte"
     viewAll          = "Alle anzeigen"
     recentPosts      = "Neueste Beiträge"
+
+[resume]
+  experience     = "Erfahrung"
+  education      = "Ausbildung"
+  skills         = "Fähigkeiten"
+  certifications = "Zertifikate"
+  languages      = "Sprachen"
+  present        = "Heute"
+  print          = "Drucken / Als PDF speichern"
+  contact        = "Kontakt"
+  summary        = "Zusammenfassung"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -83,3 +83,14 @@
     featuredProjects = "Featured Projects"
     viewAll          = "View all"
     recentPosts      = "Recent Posts"
+
+[resume]
+  experience     = "Experience"
+  education      = "Education"
+  skills         = "Skills"
+  certifications = "Certifications"
+  languages      = "Languages"
+  present        = "Present"
+  print          = "Print / Save PDF"
+  contact        = "Contact"
+  summary        = "Summary"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -83,3 +83,14 @@
     featuredProjects = "Proyectos destacados"
     viewAll          = "Ver todo"
     recentPosts      = "Artículos recientes"
+
+[resume]
+  experience     = "Experiencia"
+  education      = "Educación"
+  skills         = "Habilidades"
+  certifications = "Certificaciones"
+  languages      = "Idiomas"
+  present        = "Presente"
+  print          = "Imprimir / Guardar PDF"
+  contact        = "Contacto"
+  summary        = "Resumen"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -83,3 +83,14 @@
     featuredProjects = "Projets en vedette"
     viewAll          = "Tout voir"
     recentPosts      = "Articles récents"
+
+[resume]
+  experience     = "Expérience"
+  education      = "Formation"
+  skills         = "Compétences"
+  certifications = "Certifications"
+  languages      = "Langues"
+  present        = "Présent"
+  print          = "Imprimer / Sauvegarder en PDF"
+  contact        = "Contact"
+  summary        = "Résumé"

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -83,3 +83,14 @@
     featuredProjects = "Progetti in evidenza"
     viewAll          = "Vedi tutto"
     recentPosts      = "Articoli recenti"
+
+[resume]
+  experience     = "Esperienza"
+  education      = "Istruzione"
+  skills         = "Competenze"
+  certifications = "Certificazioni"
+  languages      = "Lingue"
+  present        = "Presente"
+  print          = "Stampa / Salva PDF"
+  contact        = "Contatto"
+  summary        = "Riepilogo"

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -80,3 +80,14 @@
     featuredProjects = "注目のプロジェクト"
     viewAll          = "すべて表示"
     recentPosts      = "最近の記事"
+
+[resume]
+  experience     = "職歴"
+  education      = "学歴"
+  skills         = "スキル"
+  certifications = "資格・認定"
+  languages      = "言語"
+  present        = "現在"
+  print          = "印刷 / PDF 保存"
+  contact        = "連絡先"
+  summary        = "概要"

--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -80,3 +80,14 @@
     featuredProjects = "추천 프로젝트"
     viewAll          = "모두 보기"
     recentPosts      = "최근 글"
+
+[resume]
+  experience     = "경력"
+  education      = "학력"
+  skills         = "기술"
+  certifications = "자격증"
+  languages      = "언어"
+  present        = "현재"
+  print          = "인쇄 / PDF 저장"
+  contact        = "연락처"
+  summary        = "소개"

--- a/i18n/pt.toml
+++ b/i18n/pt.toml
@@ -83,3 +83,14 @@
     featuredProjects = "Projetos em destaque"
     viewAll          = "Ver tudo"
     recentPosts      = "Postagens recentes"
+
+[resume]
+  experience     = "Experiência"
+  education      = "Educação"
+  skills         = "Habilidades"
+  certifications = "Certificações"
+  languages      = "Idiomas"
+  present        = "Presente"
+  print          = "Imprimir / Salvar PDF"
+  contact        = "Contato"
+  summary        = "Resumo"

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -89,3 +89,14 @@
     featuredProjects = "Избранные проекты"
     viewAll          = "Показать все"
     recentPosts      = "Последние статьи"
+
+[resume]
+  experience     = "Опыт работы"
+  education      = "Образование"
+  skills         = "Навыки"
+  certifications = "Сертификаты"
+  languages      = "Языки"
+  present        = "По настоящее время"
+  print          = "Печать / Сохранить PDF"
+  contact        = "Контакты"
+  summary        = "О себе"

--- a/i18n/vi.toml
+++ b/i18n/vi.toml
@@ -80,3 +80,14 @@
     featuredProjects = "Dự án nổi bật"
     viewAll          = "Xem tất cả"
     recentPosts      = "Bài viết mới"
+
+[resume]
+  experience     = "Kinh nghiệm"
+  education      = "Học vấn"
+  skills         = "Kỹ năng"
+  certifications = "Chứng chỉ"
+  languages      = "Ngôn ngữ"
+  present        = "Hiện tại"
+  print          = "In / Lưu PDF"
+  contact        = "Liên hệ"
+  summary        = "Tóm tắt"

--- a/i18n/zh-hans.toml
+++ b/i18n/zh-hans.toml
@@ -83,3 +83,14 @@
 
 
  
+
+[resume]
+  experience     = "工作经历"
+  education      = "教育背景"
+  skills         = "技能"
+  certifications = "证书"
+  languages      = "语言能力"
+  present        = "至今"
+  print          = "打印 / 保存为 PDF"
+  contact        = "联系方式"
+  summary        = "个人简介"

--- a/i18n/zh-hant.toml
+++ b/i18n/zh-hant.toml
@@ -80,3 +80,14 @@
     featuredProjects = "特色專案"
     viewAll          = "查看全部"
     recentPosts      = "最近文章"
+
+[resume]
+  experience     = "工作經歷"
+  education      = "教育背景"
+  skills         = "技能"
+  certifications = "證書"
+  languages      = "語言能力"
+  present        = "至今"
+  print          = "列印 / 儲存為 PDF"
+  contact        = "聯絡方式"
+  summary        = "個人簡介"

--- a/layouts/resume.html
+++ b/layouts/resume.html
@@ -1,0 +1,260 @@
+{{ define "main" }}
+  {{- $p := .Params -}}
+
+  <article class="px-4 py-6">
+    <!-- 页眉：姓名、职位、联系方式 -->
+    <header class="mb-8">
+      <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 class="text-foreground mb-1 text-3xl font-bold md:text-4xl">
+            {{ $p.name | default .Title }}
+          </h1>
+          {{ with $p.jobtitle }}
+            <p class="text-primary mb-3 text-lg font-medium">{{ . }}</p>
+          {{ end }}
+          <!-- 联系方式 -->
+          <div class="text-muted-foreground flex flex-wrap gap-x-4 gap-y-1 text-sm">
+            {{ with $p.location }}
+              <span class="flex items-center gap-1">
+                {{ partial "features/icon.html" (dict "name" "contact" "size" "xs" "ariaLabel" "") }}
+                {{ . }}
+              </span>
+            {{ end }}
+            {{ with $p.email }}
+              <a href="mailto:{{ . }}" class="hover:text-primary flex items-center gap-1 transition-colors">
+                {{ partial "features/icon.html" (dict "name" "email" "size" "xs" "ariaLabel" "") }}
+                {{ . }}
+              </a>
+            {{ end }}
+            {{ with $p.phone }}
+              <span class="flex items-center gap-1">
+                {{ partial "features/icon.html" (dict "name" "contact" "size" "xs" "ariaLabel" "") }}
+                {{ . }}
+              </span>
+            {{ end }}
+            {{ with $p.website }}
+              <a href="{{ . }}" target="_blank" rel="noopener noreferrer" class="hover:text-primary flex items-center gap-1 transition-colors">
+                {{ partial "features/icon.html" (dict "name" "external-link" "size" "xs" "ariaLabel" "") }}
+                {{ . | strings.TrimPrefix "https://" | strings.TrimPrefix "http://" }}
+              </a>
+            {{ end }}
+            {{ with $p.github }}
+              <a href="{{ . }}" target="_blank" rel="noopener noreferrer" class="hover:text-primary flex items-center gap-1 transition-colors">
+                {{ partial "features/icon.html" (dict "name" "github" "size" "xs" "ariaLabel" "GitHub") }}
+                {{ . | replaceRE `https?://github\.com/` "" }}
+              </a>
+            {{ end }}
+            {{ with $p.linkedin }}
+              <a href="{{ . }}" target="_blank" rel="noopener noreferrer" class="hover:text-primary flex items-center gap-1 transition-colors">
+                {{ partial "features/icon.html" (dict "name" "linkedin" "size" "xs" "ariaLabel" "LinkedIn") }}
+                {{ . | replaceRE `https?://(www\.)?linkedin\.com/in/` "" }}
+              </a>
+            {{ end }}
+          </div>
+        </div>
+
+      </div>
+    </header>
+
+    <!-- 概要 -->
+    {{ with $p.summary }}
+      <section class="mb-8">
+        <div class="bg-card border-border rounded-lg border p-6 shadow-sm">
+          <p class="text-foreground leading-relaxed">{{ . }}</p>
+        </div>
+      </section>
+    {{ end }}
+
+    <!-- 工作经历 -->
+    {{ with $p.experience }}
+      <section class="mb-8">
+        <h2 class="text-foreground mb-4 flex items-center gap-2 text-xl font-bold">
+          {{ partial "features/icon.html" (dict "name" "briefcase" "size" "md" "ariaLabel" "") }}
+          {{ T "resume.experience" | default "Experience" }}
+        </h2>
+        <div class="space-y-4">
+          {{ range . }}
+            <div class="resume-entry bg-card border-border rounded-lg border p-6 shadow-sm">
+              <div class="mb-3 flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between">
+                <div class="flex-1">
+                  <h3 class="text-foreground font-semibold">{{ .title }}</h3>
+                  <p class="text-primary text-sm font-medium">{{ .company }}</p>
+                  {{ with .location }}
+                    <p class="text-muted-foreground text-xs">{{ . }}</p>
+                  {{ end }}
+                </div>
+                <div class="text-muted-foreground shrink-0 text-sm">
+                  {{- $start := .start -}}
+                  {{- $end := .end -}}
+                  {{- if $start -}}
+                    {{- $startNorm := $start -}}
+                    {{- if eq (len $start) 4 -}}{{- $startNorm = printf "%s-01-01" $start -}}{{- end -}}
+                    {{- if eq (len $start) 7 -}}{{- $startNorm = printf "%s-01" $start -}}{{- end -}}
+                    {{- $startFmt := (time $startNorm).Format "Jan 2006" -}}
+                    {{- if $end -}}
+                      {{- $endNorm := $end -}}
+                      {{- if eq (len $end) 4 -}}{{- $endNorm = printf "%s-01-01" $end -}}{{- end -}}
+                      {{- if eq (len $end) 7 -}}{{- $endNorm = printf "%s-01" $end -}}{{- end -}}
+                      {{ $startFmt }} – {{ (time $endNorm).Format "Jan 2006" }}
+                    {{- else -}}
+                      {{ $startFmt }} – {{ T "resume.present" | default "Present" }}
+                    {{- end -}}
+                  {{- end -}}
+                </div>
+              </div>
+              {{ with .description }}
+                <p class="text-foreground mb-3 text-sm leading-relaxed">{{ . }}</p>
+              {{ end }}
+              {{ with .highlights }}
+                <ul class="space-y-1">
+                  {{ range . }}
+                    <li class="text-muted-foreground flex items-start gap-2 text-sm">
+                      <span class="text-primary mt-1.5 shrink-0 text-xs">▸</span>
+                      {{ . }}
+                    </li>
+                  {{ end }}
+                </ul>
+              {{ end }}
+              {{ with .stack }}
+                <div class="mt-3 flex flex-wrap gap-1.5">
+                  {{ range . }}
+                    <span class="bg-primary/10 text-primary rounded-md px-2 py-0.5 text-xs font-medium">{{ . }}</span>
+                  {{ end }}
+                </div>
+              {{ end }}
+            </div>
+          {{ end }}
+        </div>
+      </section>
+    {{ end }}
+
+    <!-- 教育经历 -->
+    {{ with $p.education }}
+      <section class="mb-8">
+        <h2 class="text-foreground mb-4 flex items-center gap-2 text-xl font-bold">
+          {{ partial "features/icon.html" (dict "name" "book-open" "size" "md" "ariaLabel" "") }}
+          {{ T "resume.education" | default "Education" }}
+        </h2>
+        <div class="space-y-4">
+          {{ range . }}
+            <div class="resume-entry bg-card border-border rounded-lg border p-6 shadow-sm">
+              <div class="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between">
+                <div class="flex-1">
+                  <h3 class="text-foreground font-semibold">{{ .degree }}</h3>
+                  <p class="text-primary text-sm font-medium">{{ .institution }}</p>
+                  {{ with .location }}
+                    <p class="text-muted-foreground text-xs">{{ . }}</p>
+                  {{ end }}
+                  {{ with .description }}
+                    <p class="text-muted-foreground mt-2 text-sm">{{ . }}</p>
+                  {{ end }}
+                </div>
+                <div class="text-muted-foreground shrink-0 text-sm">
+                  {{- $start := .start -}}
+                  {{- $end := .end -}}
+                  {{- if $start -}}
+                    {{- if $end -}}
+                      {{ $start }} – {{ $end }}
+                    {{- else -}}
+                      {{ $start }} – {{ T "resume.present" | default "Present" }}
+                    {{- end -}}
+                  {{- end -}}
+                </div>
+              </div>
+            </div>
+          {{ end }}
+        </div>
+      </section>
+    {{ end }}
+
+    <!-- 技能 -->
+    {{ with $p.skills }}
+      <section class="mb-8">
+        <h2 class="text-foreground mb-4 flex items-center gap-2 text-xl font-bold">
+          {{ partial "features/icon.html" (dict "name" "star" "size" "md" "ariaLabel" "") }}
+          {{ T "resume.skills" | default "Skills" }}
+        </h2>
+        <div class="bg-card border-border rounded-lg border p-6 shadow-sm">
+          <div class="space-y-3">
+            {{ range . }}
+              <div class="flex flex-wrap items-baseline gap-2">
+                <span class="text-muted-foreground w-28 shrink-0 text-sm font-medium">{{ .category }}</span>
+                <div class="flex flex-wrap gap-2">
+                  {{ range .items }}
+                    <span class="bg-muted text-foreground rounded-md px-2.5 py-0.5 text-sm font-medium">{{ . }}</span>
+                  {{ end }}
+                </div>
+              </div>
+            {{ end }}
+          </div>
+        </div>
+      </section>
+    {{ end }}
+
+    <!-- 证书与语言能力（两列布局） -->
+    {{ $hasCerts := $p.certifications }}
+    {{ $hasLangs := $p.languages }}
+    {{ if or $hasCerts $hasLangs }}
+      <div class="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-2">
+
+        <!-- 证书 -->
+        {{ with $hasCerts }}
+          <section>
+            <h2 class="text-foreground mb-4 flex items-center gap-2 text-xl font-bold">
+              {{ partial "features/icon.html" (dict "name" "file-text" "size" "md" "ariaLabel" "") }}
+              {{ T "resume.certifications" | default "Certifications" }}
+            </h2>
+            <div class="bg-card border-border rounded-lg border p-6 shadow-sm">
+              <ul class="space-y-3">
+                {{ range . }}
+                  <li>
+                    {{ if .url }}
+                      <a href="{{ .url }}" target="_blank" rel="noopener noreferrer" class="hover:text-primary text-foreground font-medium transition-colors">{{ .name }}</a>
+                    {{ else }}
+                      <span class="text-foreground font-medium">{{ .name }}</span>
+                    {{ end }}
+                    <p class="text-muted-foreground text-sm">
+                      {{ .issuer }}
+                      {{ with .date }}
+                        · {{ . }}
+                      {{ end }}
+                    </p>
+                  </li>
+                {{ end }}
+              </ul>
+            </div>
+          </section>
+        {{ end }}
+
+        <!-- 语言能力 -->
+        {{ with $hasLangs }}
+          <section>
+            <h2 class="text-foreground mb-4 flex items-center gap-2 text-xl font-bold">
+              {{ partial "features/icon.html" (dict "name" "language" "size" "md" "ariaLabel" "") }}
+              {{ T "resume.languages" | default "Languages" }}
+            </h2>
+            <div class="bg-card border-border rounded-lg border p-6 shadow-sm">
+              <ul class="space-y-2">
+                {{ range . }}
+                  <li class="flex items-center justify-between">
+                    <span class="text-foreground font-medium">{{ .language }}</span>
+                    <span class="text-muted-foreground text-sm">{{ .level }}</span>
+                  </li>
+                {{ end }}
+              </ul>
+            </div>
+          </section>
+        {{ end }}
+
+      </div>
+    {{ end }}
+
+    <!-- 页面正文（可选额外 Markdown 内容） -->
+    {{ with .Content }}
+      <div class="prose prose-neutral dark:prose-invert max-w-none">
+        {{ . }}
+      </div>
+    {{ end }}
+
+  </article>
+{{ end }}


### PR DESCRIPTION
## 📃 Description

Adds a new `resume` layout — a fully frontmatter-driven Resume / CV page that fits naturally into Hugo Narrow's existing page type system.

## 🪵 Changelog

### ➕ Added

- `layouts/resume.html` — new Resume / CV page layout
- Sections for experience, education, skills, certifications, and spoken languages
- Tech stack tag chips per experience entry
- `archetypes/resume.md` — full frontmatter schema
- `exampleSite/content/resume.md` — example resume content
- `assets/icons/briefcase.svg` and `assets/icons/printer.svg`
- `[resume]` i18n strings across all 13 supported languages
- Resume entry added to example site footer menu

### ✏️ Changed

- `assets/css/prose.misc.css` — added `@media print` block to hide site chrome and produce clean PDF output

## 📷 Screenshots

<img width="972" height="613" alt="Scherm­afbeelding 2026-05-05 om 20 49 03" src="https://github.com/user-attachments/assets/f31c15ea-057f-4d7e-b735-296ba6e79625" />
<img width="933" height="362" alt="Scherm­afbeelding 2026-05-05 om 20 49 15" src="https://github.com/user-attachments/assets/9cdb49e0-9dc6-4636-997d-bb25bc8d2fcd" />
<img width="921" height="500" alt="Scherm­afbeelding 2026-05-05 om 20 49 10" src="https://github.com/user-attachments/assets/9421c20c-b9cd-4f2f-886d-5786588b9ea6" />


