### PR TITLE
feat: add icons and compact styling to admonitions

### DIFF
--- a/layouts/_markup/render-blockquote.html
+++ b/layouts/_markup/render-blockquote.html
@@ -12,22 +12,27 @@
   {{- $alertConfig := dict
     "note" (dict
     "colorVar" "note"
+    "icon" "info-circle"
     "defaultTitle" (T "article.alert.note")
     )
     "tip" (dict
     "colorVar" "tip"
+    "icon" "lightbulb"
     "defaultTitle" (T "article.alert.tip")
     )
     "important" (dict
     "colorVar" "important"
+    "icon" "alert-circle"
     "defaultTitle" (T "article.alert.important")
     )
     "warning" (dict
     "colorVar" "warning"
+    "icon" "alert-triangle"
     "defaultTitle" (T "article.alert.warning")
     )
     "caution" (dict
     "colorVar" "caution"
+    "icon" "alert-triangle"
     "defaultTitle" (T "article.alert.caution")
     )
     -}}
@@ -53,7 +58,7 @@
     <div
       class="{{ if $isCollapsible }}
         cursor-pointer
-      {{ end }} flex items-center justify-between px-6 py-6"
+      {{ end }} flex items-center justify-between px-4 py-3"
       {{ if $isCollapsible }}
         onclick="toggleAlert('{{ $alertId }}')" role="button" tabindex="0"
         aria-expanded="{{ $isExpanded }}" aria-controls="{{ $alertId }}-content"
@@ -61,8 +66,12 @@
       {{ end }}
     >
       <div class="flex items-center gap-3">
+        {{/* Alert icon */}}
+        <span style="color: var(--color-{{ $config.colorVar }});" class="shrink-0">
+          {{ partial "features/icon.html" (dict "name" $config.icon "size" "sm" "hidden" true) }}
+        </span>
         {{/* Alert title */}}
-        <h4 id="{{ $alertId }}-title" class="text-foreground/90 m-0 font-semibold">
+        <h4 id="{{ $alertId }}-title" class="text-foreground/90 m-0 text-base font-semibold">
           {{ $title }}
         </h4>
       </div>
@@ -80,7 +89,7 @@
       id="{{ $alertId }}-content"
       class="alert-content {{ if and $isCollapsible (not $isExpanded) }}
         hidden
-      {{ end }} px-6 pb-6"
+      {{ end }} px-4 pb-3"
     >
       <div class="prose prose-sm text-foreground/90 max-w-none">
         {{ .Text }}


### PR DESCRIPTION
## 📃 Description

Improves the existing GitHub-style alert/admonition blocks with colored icons and tighter spacing. The render hook already supported all 5 alert types (note, tip, important, warning, caution) with color tokens, collapsible syntax, and i18n — this PR wires in the matching SVG icons and reduces padding for a more compact look.

## 🪵 Changelog

### ✏️ Changed

- Alert header and content padding reduced (`px-6 py-6` → `px-4 py-3`) for a more compact appearance
- Alert title font size explicitly set to `text-base` to stay in balance with surrounding prose

### ➕ Added

- Colored icon added to each alert type header:
  - **Note** → `info-circle`
  - **Tip** → `lightbulb`
  - **Important** → `alert-circle`
  - **Warning** → `alert-triangle`
  - **Caution** → `alert-triangle`
- Icon color inherits from the alert's existing color token (`--color-note`, `--color-tip`, etc.)

## 📷 Screenshots

<img width="925" height="692" alt="Scherm­afbeelding 2026-05-05 om 21 03 35" src="https://github.com/user-attachments/assets/e3fcc15b-955d-44f7-b19a-f9b9e550d02e" />
