### PR TITLE
feat: add snippet style pages

### DIFF
--- a/archetypes/snippets.md
+++ b/archetypes/snippets.md
@@ -1,0 +1,9 @@
+---
+title: "{{ replace .File.ContentBaseName "-" " " | title }}"
+date: {{ .Date }}
+draft: false
+slug: ""
+description: ""
+tags: []
+language: ""
+---

--- a/exampleSite/config/_default/hugo.yaml
+++ b/exampleSite/config/_default/hugo.yaml
@@ -17,6 +17,7 @@ mainSections: ["posts"]  # Multiple values can be configured, e.g. ["posts", "bl
 permalinks:
   posts: /posts/:slug/
   projects: /projects/:slug/
+  snippets: /snippets/:slug/
   pages: /:slug/
 
 # pagination

--- a/exampleSite/config/_default/menus.yaml
+++ b/exampleSite/config/_default/menus.yaml
@@ -45,6 +45,13 @@ main:
     params:
       icon: projects
 
+  - name: Snippets
+    weight: 5
+    pageRef: /snippets
+    parent: More
+    params:
+      icon: code
+
 
 
 # footer menu

--- a/exampleSite/content/snippets/_index.md
+++ b/exampleSite/content/snippets/_index.md
@@ -1,0 +1,4 @@
+---
+title: Snippets
+description: Short, focused code recipes — copy and adapt.
+---

--- a/exampleSite/content/snippets/css-custom-scrollbar/index.md
+++ b/exampleSite/content/snippets/css-custom-scrollbar/index.md
@@ -1,0 +1,42 @@
+---
+title: "Custom scrollbar with CSS"
+date: 2024-04-22
+draft: false
+slug: "css-custom-scrollbar"
+description: "Minimal, cross-browser custom scrollbar using only CSS custom properties."
+tags: ["scrollbar", "ux"]
+language: "css"
+---
+
+```css
+/* Works in Chrome, Edge, Safari */
+:root {
+  --scrollbar-width: 6px;
+  --scrollbar-track: transparent;
+  --scrollbar-thumb: oklch(60% 0.05 250);
+  --scrollbar-thumb-hover: oklch(50% 0.08 250);
+}
+
+* {
+  scrollbar-width: thin; /* Firefox */
+  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+}
+
+*::-webkit-scrollbar {
+  width: var(--scrollbar-width);
+  height: var(--scrollbar-width);
+}
+
+*::-webkit-scrollbar-track {
+  background: var(--scrollbar-track);
+}
+
+*::-webkit-scrollbar-thumb {
+  background: var(--scrollbar-thumb);
+  border-radius: 999px;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background: var(--scrollbar-thumb-hover);
+}
+```

--- a/exampleSite/content/snippets/go-http-retry/index.md
+++ b/exampleSite/content/snippets/go-http-retry/index.md
@@ -1,0 +1,40 @@
+---
+title: "HTTP client with exponential backoff retry"
+date: 2024-03-10
+draft: false
+slug: "go-http-retry"
+description: "A reusable HTTP GET wrapper that retries on transient errors with exponential backoff."
+tags: ["http", "retry", "networking"]
+language: "go"
+---
+
+```go
+package main
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"time"
+)
+
+func getWithRetry(url string, maxRetries int) (*http.Response, error) {
+	client := &http.Client{Timeout: 10 * time.Second}
+
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		resp, err := client.Get(url)
+		if err == nil && resp.StatusCode < 500 {
+			return resp, nil
+		}
+
+		if attempt == maxRetries {
+			return nil, fmt.Errorf("failed after %d attempts", maxRetries+1)
+		}
+
+		wait := time.Duration(math.Pow(2, float64(attempt))) * 100 * time.Millisecond
+		time.Sleep(wait)
+	}
+
+	return nil, nil
+}
+```

--- a/i18n/ar.toml
+++ b/i18n/ar.toml
@@ -95,3 +95,8 @@
     featuredProjects = "مشاريع مميزة"
     viewAll          = "عرض الكل"
     recentPosts      = "أحدث المقالات"
+
+
+[snippet]
+    empty    = "لا توجد مقتطفات بعد"
+    language = "اللغة"

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -83,3 +83,8 @@
     featuredProjects = "Ausgewählte Projekte"
     viewAll          = "Alle anzeigen"
     recentPosts      = "Neueste Beiträge"
+
+
+[snippet]
+    empty    = "Noch keine Snippets"
+    language = "Sprache"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -83,3 +83,8 @@
     featuredProjects = "Featured Projects"
     viewAll          = "View all"
     recentPosts      = "Recent Posts"
+
+
+[snippet]
+    empty    = "No snippets yet"
+    language = "Language"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -83,3 +83,8 @@
     featuredProjects = "Proyectos destacados"
     viewAll          = "Ver todo"
     recentPosts      = "Artículos recientes"
+
+
+[snippet]
+    empty    = "Aún no hay snippets"
+    language = "Lenguaje"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -83,3 +83,8 @@
     featuredProjects = "Projets en vedette"
     viewAll          = "Tout voir"
     recentPosts      = "Articles récents"
+
+
+[snippet]
+    empty    = "Pas encore de snippets"
+    language = "Langage"

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -83,3 +83,8 @@
     featuredProjects = "Progetti in evidenza"
     viewAll          = "Vedi tutto"
     recentPosts      = "Articoli recenti"
+
+
+[snippet]
+    empty    = "Nessuno snippet ancora"
+    language = "Linguaggio"

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -80,3 +80,8 @@
     featuredProjects = "注目のプロジェクト"
     viewAll          = "すべて表示"
     recentPosts      = "最近の記事"
+
+
+[snippet]
+    empty    = "スニペットはまだありません"
+    language = "言語"

--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -80,3 +80,8 @@
     featuredProjects = "추천 프로젝트"
     viewAll          = "모두 보기"
     recentPosts      = "최근 글"
+
+
+[snippet]
+    empty    = "아직 스니펫이 없습니다"
+    language = "언어"

--- a/i18n/pt.toml
+++ b/i18n/pt.toml
@@ -83,3 +83,8 @@
     featuredProjects = "Projetos em destaque"
     viewAll          = "Ver tudo"
     recentPosts      = "Postagens recentes"
+
+
+[snippet]
+    empty    = "Ainda sem snippets"
+    language = "Linguagem"

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -89,3 +89,8 @@
     featuredProjects = "Избранные проекты"
     viewAll          = "Показать все"
     recentPosts      = "Последние статьи"
+
+
+[snippet]
+    empty    = "Пока нет сниппетов"
+    language = "Язык"

--- a/i18n/vi.toml
+++ b/i18n/vi.toml
@@ -80,3 +80,8 @@
     featuredProjects = "Dự án nổi bật"
     viewAll          = "Xem tất cả"
     recentPosts      = "Bài viết mới"
+
+
+[snippet]
+    empty    = "Chưa có đoạn mã nào"
+    language = "Ngôn ngữ"

--- a/i18n/zh-hans.toml
+++ b/i18n/zh-hans.toml
@@ -83,3 +83,8 @@
 
 
  
+
+
+[snippet]
+    empty    = "暂无代码片段"
+    language = "语言"

--- a/i18n/zh-hant.toml
+++ b/i18n/zh-hant.toml
@@ -80,3 +80,8 @@
     featuredProjects = "特色專案"
     viewAll          = "查看全部"
     recentPosts      = "最近文章"
+
+
+[snippet]
+    empty    = "暫無程式碼片段"
+    language = "語言"

--- a/layouts/_partials/content/snippet-card.html
+++ b/layouts/_partials/content/snippet-card.html
@@ -1,0 +1,61 @@
+{{/* Snippet card component - compact, code-focused, no cover image
+  @context {page} .page The snippet page object
+*/}}
+
+{{ $page := .page }}
+
+{{- $summaryContent := "" -}}
+{{- if $page.Params.description -}}
+  {{- $summaryContent = $page.Params.description -}}
+{{- else if $page.Params.summary -}}
+  {{- $summaryContent = $page.Params.summary -}}
+{{- else if $page.Summary -}}
+  {{- $summaryContent = $page.Summary | plainify | truncate 140 -}}
+{{- end -}}
+
+<article class="group h-full">
+  <a href="{{ $page.RelPermalink }}" class="block h-full">
+    <div
+      class="bg-card border-border hover:bg-primary/5 hover:border-primary/20 focus:ring-primary/20 relative flex h-full flex-col overflow-hidden rounded-xl border p-6 transition-all duration-300 ease-out hover:-translate-y-1 hover:scale-[1.02] hover:shadow-lg focus:ring-2 focus:outline-none"
+    >
+      <!-- Language badge + title row -->
+      <div class="mb-3 flex items-start gap-3">
+        {{- if $page.Params.language -}}
+          <span class="bg-primary/10 text-primary mt-0.5 shrink-0 rounded-md px-2 py-0.5 font-mono text-xs font-semibold">
+            {{ $page.Params.language }}
+          </span>
+        {{- end -}}
+        <h3 class="text-foreground group-hover:text-primary text-lg leading-snug font-bold transition-colors duration-200">
+          {{ $page.Title }}
+        </h3>
+      </div>
+
+      <!-- Description -->
+      {{- if $summaryContent -}}
+        <p class="text-muted-foreground mb-4 line-clamp-2 text-sm leading-relaxed">
+          {{ $summaryContent }}
+        </p>
+      {{- end -}}
+
+      <!-- Meta: tags + date -->
+      <div class="text-muted-foreground mt-auto flex flex-wrap items-center gap-x-4 gap-y-2 text-sm">
+        {{- if isset $page.Params "tags" -}}
+          <div class="flex flex-wrap items-center gap-1.5">
+            {{ range $page.Params.tags }}
+              <span class="bg-muted/50 border-muted/30 rounded-md border px-2 py-0.5 text-xs font-medium">
+                {{ . }}
+              </span>
+            {{ end }}
+          </div>
+        {{- end -}}
+
+        <div class="ml-auto flex items-center gap-1.5">
+          {{ partial "features/icon.html" (dict "name" "calendar" "size" "sm" "ariaLabel" "") }}
+          <time datetime="{{ $page.Date.Format `2006-01-02` }}" class="font-medium">
+            {{ partial "helpers/date.html" (dict "date" $page.Date "variant" "long") }}
+          </time>
+        </div>
+      </div>
+    </div>
+  </a>
+</article>

--- a/layouts/snippets/list.html
+++ b/layouts/snippets/list.html
@@ -1,0 +1,64 @@
+{{ define "main" }}
+  <div class="mx-auto py-6">
+    <!-- 页面标题和描述 -->
+    <header class="mb-8">
+      <h1 class="text-foreground mb-4 text-3xl font-bold">
+        {{ .Title }}
+      </h1>
+
+      {{ if .Content }}
+        <div class="prose prose-neutral dark:prose-invert max-w-none">
+          {{ .Content }}
+        </div>
+      {{ else if .Description }}
+        <p class="text-muted-foreground">
+          {{ .Description }}
+        </p>
+      {{ end }}
+
+      <!-- 统计信息 -->
+      <div class="text-muted-foreground mt-4 flex items-center gap-4 text-sm">
+        <div class="flex items-center gap-1">
+          {{ partial "features/icon.html" (dict "name" "code" "size" "sm" "ariaLabel" "") }}
+          <span>{{ T "list.pages" (dict "count" .Paginator.TotalNumberOfElements) }}</span>
+        </div>
+        {{ if gt .Paginator.TotalPages 1 }}
+          <div class="flex items-center gap-1">
+            {{ partial "features/icon.html" (dict "name" "layers" "size" "sm" "ariaLabel" "") }}
+            <span>{{ .Paginator.PageNumber }} / {{ .Paginator.TotalPages }}</span>
+          </div>
+        {{ end }}
+      </div>
+    </header>
+
+    <!-- 内容列表 -->
+    {{ $pages := .Paginator.Pages }}
+    {{ if $pages }}
+      <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {{ range $pages }}
+          {{ partial "content/snippet-card.html" (dict "page" .) }}
+        {{ end }}
+      </div>
+    {{ else }}
+      <!-- 空状态 -->
+      <div class="py-16 text-center">
+        <div class="bg-muted/50 mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-full">
+          {{ partial "features/icon.html" (dict "name" "code" "size" "xl" "ariaLabel" "") }}
+        </div>
+        <h2 class="text-foreground mb-3 text-xl font-medium">
+          {{ T "snippet.empty" }}
+        </h2>
+        <a
+          href="{{ `/` | relLangURL }}"
+          class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex items-center gap-2 rounded-xl px-6 py-3 font-medium transition-colors duration-300"
+        >
+          {{ partial "features/icon.html" (dict "name" "home" "size" "sm" "ariaLabel" "") }}
+          <span>{{ T "nav.backHome" }}</span>
+        </a>
+      </div>
+    {{ end }}
+
+    <!-- 分页导航 -->
+    {{ partial "navigation/pagination.html" . }}
+  </div>
+{{ end }}

--- a/layouts/snippets/single.html
+++ b/layouts/snippets/single.html
@@ -1,0 +1,60 @@
+{{ define "main" }}
+  <!-- 头部信息 -->
+  <header class="mb-8">
+    <!-- 语言标签 -->
+    {{- if .Params.language -}}
+      <div class="mb-4">
+        <span class="bg-primary/10 text-primary rounded-md px-3 py-1 font-mono text-sm font-semibold">
+          {{ .Params.language }}
+        </span>
+      </div>
+    {{- end -}}
+
+    <!-- 标题 -->
+    <h1 class="text-foreground mb-4 text-3xl leading-tight font-bold md:text-4xl">
+      {{ .Title }}
+    </h1>
+
+    <!-- 描述 -->
+    {{- if .Params.description -}}
+      <p class="text-muted-foreground mb-6 text-lg leading-relaxed">
+        {{ .Params.description }}
+      </p>
+    {{- end -}}
+
+    <!-- 日期与标签 -->
+    <div class="bg-card border-border rounded-xl border p-5">
+      <div class="text-muted-foreground flex flex-wrap items-center gap-x-5 gap-y-3 text-sm">
+        <div class="flex items-center gap-2">
+          {{ partial "features/icon.html" (dict "name" "calendar" "size" "sm" "ariaLabel" "") }}
+          <time datetime="{{ .Date.Format `2006-01-02` }}">
+            {{ partial "helpers/date.html" (dict "date" .Date "variant" "long") }}
+          </time>
+        </div>
+
+        {{- $tags := .GetTerms "tags" -}}
+        {{- if $tags -}}
+          <div class="flex flex-wrap items-center gap-1.5">
+            {{ partial "features/icon.html" (dict "name" "tags" "size" "sm" "ariaLabel" "") }}
+            {{- range $tags -}}
+              <a
+                href="{{ .RelPermalink }}"
+                class="bg-muted/50 hover:bg-muted text-muted-foreground hover:text-foreground rounded-full px-2.5 py-1 text-xs font-medium transition-colors duration-200"
+              >
+                {{ .LinkTitle }}
+              </a>
+            {{- end -}}
+          </div>
+        {{- end -}}
+      </div>
+    </div>
+  </header>
+
+  <!-- 内容 -->
+  <article class="prose prose-neutral dark:prose-invert mb-12 max-w-none">
+    {{ .Content }}
+  </article>
+
+  <!-- 评论 -->
+  {{ partial "features/comments.html" . }}
+{{ end }}


### PR DESCRIPTION
## 📃 Description

Adds a `snippets` content type — short, code-focused entries distinct from posts. Each snippet carries a `language` field that renders as a badge on the list cards and single pages. The single page is intentionally lightweight: no cover image, no license, no related posts, no prev/next navigation.

## 🪵 Changelog

### ➕ Added

- New `snippets` content type with its own list and single page layouts
- `snippet-card` partial — compact 2-column grid card with language badge, description, tags, and date
- `archetypes/snippets.md` with `language`, `description`, `tags`, `slug`, and `draft` fields
- `[snippet]` i18n keys (`empty`, `language`) in all 13 supported locales
- Example snippets: Go HTTP retry with exponential backoff, CSS custom scrollbar
- `snippets: /snippets/:slug/` permalink in example site config
- Snippets entry in the "More" nav dropdown (`menus.yaml`)

## 📷 Screenshots

<img width="1017" height="552" alt="Scherm­afbeelding 2026-05-05 om 21 17 12" src="https://github.com/user-attachments/assets/83f7058a-e22e-4155-8b66-32cbfa4f1bb4" />
<img width="984" height="499" alt="Scherm­afbeelding 2026-05-05 om 21 17 07" src="https://github.com/user-attachments/assets/cb7fd6b2-ddac-4763-9834-84f85c43bea3" />
