### PR TITLE
feat: add theme-aware image support for dark/light mode

### DIFF
--- a/assets/css/custom/theme-images.css
+++ b/assets/css/custom/theme-images.css
@@ -1,0 +1,4 @@
+/* Dark/light mode image variants — toggled by .dark class on <html> */
+.theme-img-dark { display: none; }
+.dark .theme-img-light { display: none; }
+.dark .theme-img-dark { display: block; }

--- a/assets/js/gallery-lightbox.js
+++ b/assets/js/gallery-lightbox.js
@@ -105,7 +105,8 @@ class GalleryLightbox {
     const hasCaption = this.config.showCaption && Boolean(item.captionHTML);
     const isSingleItem = items.length <= 1;
 
-    this.elements.image.src = item.src;
+    const isDark = document.documentElement.classList.contains('dark');
+    this.elements.image.src = (isDark && item.darkSrc) ? item.darkSrc : (item.lightSrc || item.src);
     this.elements.image.alt = item.alt || '';
     this.elements.counter.textContent = String(this.currentIndex + 1) + ' / ' + String(items.length);
     this.elements.caption.innerHTML = hasCaption ? item.captionHTML : '';

--- a/assets/js/gallery.js
+++ b/assets/js/gallery.js
@@ -197,14 +197,19 @@ class ImageGallery {
     const lightboxItems = [];
 
     figures.forEach((figure) => {
-      const img = figure.querySelector('img');
+      const lightImgEl = figure.querySelector('.theme-img-light img') || figure.querySelector('img');
+      const darkImgEl = figure.querySelector('.theme-img-dark img');
+      const isDark = document.documentElement.classList.contains('dark');
+      const img = (isDark && darkImgEl) ? darkImgEl : lightImgEl;
       const caption = figure.querySelector('.image-caption');
 
       if (!img) {
         return;
       }
 
-      const fullSizeSrc = figure.getAttribute('data-image-src') || img.currentSrc || img.src;
+      const lightSrc = figure.getAttribute('data-image-src') || lightImgEl?.src;
+      const darkSrc = darkImgEl ? darkImgEl.src : null;
+      const fullSizeSrc = isDark && darkSrc ? darkSrc : lightSrc;
       const previewSrc = img.currentSrc || img.src;
       const width = parseInt(figure.getAttribute('data-image-width'), 10) || img.naturalWidth || 800;
       const height = parseInt(figure.getAttribute('data-image-height'), 10) || img.naturalHeight || 600;
@@ -218,6 +223,8 @@ class ImageGallery {
 
       lightboxItems.push({
         src: fullSizeSrc,
+        lightSrc,
+        darkSrc,
         width,
         height,
         alt: img.alt || '',
@@ -309,7 +316,10 @@ class ImageGallery {
     }
 
     figures.forEach((figure) => {
-      const img = figure.querySelector('img');
+      const lightImgEl = figure.querySelector('.theme-img-light img') || figure.querySelector('img');
+      const darkImgEl = figure.querySelector('.theme-img-dark img');
+      const isDark = document.documentElement.classList.contains('dark');
+      const img = (isDark && darkImgEl) ? darkImgEl : lightImgEl;
       const caption = figure.querySelector('.image-caption');
       if (!img) {
         return;
@@ -318,12 +328,16 @@ class ImageGallery {
       const galleryId = 'single-image-' + String(this.singleImageCount);
       this.singleImageCount += 1;
 
-      const src = figure.getAttribute('data-image-src') || img.currentSrc || img.src;
+      const lightSrc = figure.getAttribute('data-image-src') || lightImgEl?.src;
+      const darkSrc = darkImgEl ? darkImgEl.src : null;
+      const src = isDark && darkSrc ? darkSrc : lightSrc;
       const width = parseInt(figure.getAttribute('data-image-width'), 10) || img.naturalWidth || 800;
       const height = parseInt(figure.getAttribute('data-image-height'), 10) || img.naturalHeight || 600;
 
       this.lightbox.registerGallery(galleryId, [{
         src,
+        lightSrc,
+        darkSrc,
         width,
         height,
         alt: img.alt || '',

--- a/exampleSite/content/posts/markdown-test/index.md
+++ b/exampleSite/content/posts/markdown-test/index.md
@@ -160,6 +160,22 @@ async function fetchUser(id) {
 
 ![Sample Image](/images/01.avif "Sample Image")
 
+### Theme-Aware Images
+
+Add `|dark:path` to the image title to supply a dark-mode variant. The theme automatically shows the right image when the reader switches between light and dark mode — no JavaScript required.
+
+![Request flow diagram](/images/theme-demo-light.svg "Request flow diagram|dark:/images/theme-demo-dark.svg")
+
+The Markdown syntax for the image above:
+
+```markdown
+![alt text](light.png "My caption|dark:dark.png")
+![alt text](light.png "dark:dark.png")
+```
+
+Use `"caption|dark:dark-path"` when you want both a caption and a dark variant, or `"dark:dark-path"` when you only need the dark variant with no caption. Images without `dark:` in the title are displayed as normal.
+
+
 ## Links
 
 This is a [regular link](https://example.com).

--- a/exampleSite/static/images/theme-demo-dark.svg
+++ b/exampleSite/static/images/theme-demo-dark.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 220" width="600" height="220">
+  <rect width="600" height="220" fill="#1e1e2e" rx="12"/>
+
+  <!-- Title -->
+  <text x="300" y="36" font-family="sans-serif" font-size="15" font-weight="600" fill="#cdd6f4" text-anchor="middle">Request Flow (Dark Mode)</text>
+
+  <!-- Boxes -->
+  <rect x="30" y="60" width="120" height="44" rx="8" fill="#313244" stroke="#45475a" stroke-width="1.5"/>
+  <text x="90" y="87" font-family="sans-serif" font-size="13" fill="#cdd6f4" text-anchor="middle">Browser</text>
+
+  <rect x="240" y="60" width="120" height="44" rx="8" fill="#1e3a5f" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="300" y="87" font-family="sans-serif" font-size="13" fill="#93c5fd" text-anchor="middle">API Server</text>
+
+  <rect x="450" y="60" width="120" height="44" rx="8" fill="#14342a" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="510" y="87" font-family="sans-serif" font-size="13" fill="#86efac" text-anchor="middle">Database</text>
+
+  <!-- Arrows -->
+  <line x1="150" y1="82" x2="238" y2="82" stroke="#585b70" stroke-width="1.5" marker-end="url(#arr-dark)"/>
+  <line x1="360" y1="82" x2="448" y2="82" stroke="#585b70" stroke-width="1.5" marker-end="url(#arr-dark)"/>
+
+  <!-- Return arrows -->
+  <line x1="238" y1="94" x2="150" y2="94" stroke="#45475a" stroke-width="1.5" stroke-dasharray="4 3" marker-end="url(#arr-dark-muted)"/>
+  <line x1="448" y1="94" x2="360" y2="94" stroke="#45475a" stroke-width="1.5" stroke-dasharray="4 3" marker-end="url(#arr-dark-muted)"/>
+
+  <!-- Labels -->
+  <text x="194" y="76" font-family="sans-serif" font-size="10" fill="#6c7086" text-anchor="middle">request</text>
+  <text x="194" y="108" font-family="sans-serif" font-size="10" fill="#45475a" text-anchor="middle">response</text>
+  <text x="404" y="76" font-family="sans-serif" font-size="10" fill="#6c7086" text-anchor="middle">query</text>
+  <text x="404" y="108" font-family="sans-serif" font-size="10" fill="#45475a" text-anchor="middle">result</text>
+
+  <!-- Caption -->
+  <text x="300" y="180" font-family="sans-serif" font-size="11" fill="#6c7086" text-anchor="middle">Shown in dark mode — dark background, light text</text>
+
+  <defs>
+    <marker id="arr-dark" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#585b70"/>
+    </marker>
+    <marker id="arr-dark-muted" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#45475a"/>
+    </marker>
+  </defs>
+</svg>

--- a/exampleSite/static/images/theme-demo-light.svg
+++ b/exampleSite/static/images/theme-demo-light.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 220" width="600" height="220">
+  <rect width="600" height="220" fill="#ffffff" rx="12"/>
+
+  <!-- Title -->
+  <text x="300" y="36" font-family="sans-serif" font-size="15" font-weight="600" fill="#111827" text-anchor="middle">Request Flow (Light Mode)</text>
+
+  <!-- Boxes -->
+  <rect x="30" y="60" width="120" height="44" rx="8" fill="#f3f4f6" stroke="#d1d5db" stroke-width="1.5"/>
+  <text x="90" y="87" font-family="sans-serif" font-size="13" fill="#374151" text-anchor="middle">Browser</text>
+
+  <rect x="240" y="60" width="120" height="44" rx="8" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1.5"/>
+  <text x="300" y="87" font-family="sans-serif" font-size="13" fill="#1d4ed8" text-anchor="middle">API Server</text>
+
+  <rect x="450" y="60" width="120" height="44" rx="8" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1.5"/>
+  <text x="510" y="87" font-family="sans-serif" font-size="13" fill="#15803d" text-anchor="middle">Database</text>
+
+  <!-- Arrows -->
+  <line x1="150" y1="82" x2="238" y2="82" stroke="#6b7280" stroke-width="1.5" marker-end="url(#arr-light)"/>
+  <line x1="360" y1="82" x2="448" y2="82" stroke="#6b7280" stroke-width="1.5" marker-end="url(#arr-light)"/>
+
+  <!-- Return arrows -->
+  <line x1="238" y1="94" x2="150" y2="94" stroke="#9ca3af" stroke-width="1.5" stroke-dasharray="4 3" marker-end="url(#arr-light-gray)"/>
+  <line x1="448" y1="94" x2="360" y2="94" stroke="#9ca3af" stroke-width="1.5" stroke-dasharray="4 3" marker-end="url(#arr-light-gray)"/>
+
+  <!-- Labels -->
+  <text x="194" y="76" font-family="sans-serif" font-size="10" fill="#6b7280" text-anchor="middle">request</text>
+  <text x="194" y="108" font-family="sans-serif" font-size="10" fill="#9ca3af" text-anchor="middle">response</text>
+  <text x="404" y="76" font-family="sans-serif" font-size="10" fill="#6b7280" text-anchor="middle">query</text>
+  <text x="404" y="108" font-family="sans-serif" font-size="10" fill="#9ca3af" text-anchor="middle">result</text>
+
+  <!-- Caption -->
+  <text x="300" y="180" font-family="sans-serif" font-size="11" fill="#9ca3af" text-anchor="middle">Shown in light mode — white background, dark text</text>
+
+  <defs>
+    <marker id="arr-light" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#6b7280"/>
+    </marker>
+    <marker id="arr-light-gray" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#9ca3af"/>
+    </marker>
+  </defs>
+</svg>

--- a/layouts/_markup/render-image.html
+++ b/layouts/_markup/render-image.html
@@ -6,6 +6,16 @@
 {{- $dest := .Destination | safeURL -}}
 {{- $alt := .Text -}}
 {{- $caption := .Title -}}
+{{- $darkSrc := "" -}}
+{{/* 从 title 中解析深色模式图片路径，格式：caption|dark:path 或 dark:path */}}
+{{- if in .Title "|dark:" -}}
+  {{- $parts := split .Title "|dark:" -}}
+  {{- $caption = index $parts 0 -}}
+  {{- $darkSrc = index $parts 1 | safeURL -}}
+{{- else if hasPrefix .Title "dark:" -}}
+  {{- $caption = "" -}}
+  {{- $darkSrc = strings.TrimPrefix "dark:" .Title | safeURL -}}
+{{- end -}}
 
 {{/* 检查是否启用灯箱功能 */}}
 {{- $globalLightbox := site.Params.lightbox | default dict -}}
@@ -67,16 +77,43 @@
   data-image-src="{{ $imageUrl }}"
 >
   <div class="image-container">
-    {{/* 使用图片处理器生成图片HTML */}}
-    {{- partial "content/image-processor.html" (dict
-      "context" $pageContext
-      "src" $dest
-      "alt" $alt
-      "caption" $caption
-      "enablePlaceholder" false
-      "outputType" "img"
-      )
-    -}}
+    {{- if $darkSrc -}}
+      {{/* 浅色模式图片 */}}
+      <span class="theme-img-light">
+        {{- partial "content/image-processor.html" (dict
+          "context" $pageContext
+          "src" $dest
+          "alt" $alt
+          "caption" $caption
+          "enablePlaceholder" false
+          "outputType" "img"
+          )
+        -}}
+      </span>
+      {{/* 深色模式图片 */}}
+      <span class="theme-img-dark">
+        {{- partial "content/image-processor.html" (dict
+          "context" $pageContext
+          "src" $darkSrc
+          "alt" $alt
+          "caption" $caption
+          "enablePlaceholder" false
+          "outputType" "img"
+          )
+        -}}
+      </span>
+    {{- else -}}
+      {{/* 使用图片处理器生成图片HTML */}}
+      {{- partial "content/image-processor.html" (dict
+        "context" $pageContext
+        "src" $dest
+        "alt" $alt
+        "caption" $caption
+        "enablePlaceholder" false
+        "outputType" "img"
+        )
+      -}}
+    {{- end -}}
   </div>
 
   {{/* 图片说明 */}}


### PR DESCRIPTION
## 📃 Description

Adds support for theme-aware images — authors can supply a dark-mode variant of any image using a `|dark:` marker in the image title. The correct image is shown automatically based on the active theme, and the lightbox also respects the current mode.

## 🪵 Changelog

### ➕ Added

- Theme-aware image support: `![alt](light.png "caption|dark:dark.png")` shows different images in light and dark mode
- `assets/css/custom/theme-images.css` — CSS rules that toggle `.theme-img-light` / `.theme-img-dark` visibility via the existing `.dark` class
- Example in the Markdown Syntax Guide with light/dark SVG demo images

### ✏️ Changed

- `layouts/_markup/render-image.html` — parses `|dark:path` (or `dark:path`) from the image title and renders two `<span>`-wrapped images when a dark variant is provided
- `assets/js/gallery.js` — both single-image and gallery-group paths now read `lightSrc`/`darkSrc` from the DOM and store both in the lightbox item
- `assets/js/gallery-lightbox.js` — `render()` resolves the correct src from `lightSrc`/`darkSrc` at display time so the lightbox respects theme changes
